### PR TITLE
[Fix] Produtos Kit / Remover Press to Select da listagem de grupos de componentes

### DIFF
--- a/src/components/ui/form-autocomplete/FormAutocomplete.scss
+++ b/src/components/ui/form-autocomplete/FormAutocomplete.scss
@@ -31,6 +31,10 @@
 
 		.choices__button {
 			background-size: 12px !important;
+
+			@include darkmode {
+				filter: invert(1);
+			}
 		}
 
 		.choices__item {

--- a/src/components/ui/form-autocomplete/FormAutocomplete.vue
+++ b/src/components/ui/form-autocomplete/FormAutocomplete.vue
@@ -12,7 +12,8 @@ export interface Props {
 	size?: string
 	last?: boolean
 	template?: any
-	position?: 'top' | 'bottom' | 'auto'
+	position?: 'top' | 'bottom' | 'auto',
+	config: object
 }
 
 const emit = defineEmits(['update:modelValue', 'open', 'close', 'update'])
@@ -46,7 +47,8 @@ const settings = computed(() => {
 		noChoicesText: 'Sem opções para escolher',
 		items: [],
 		choices: _choices,
-		allowHTML: false
+		allowHTML: false,
+		...props.config
 	}
 
 	if (props.template?.choice) {


### PR DESCRIPTION
## [Fix] Produtos Kit / Remover Press to Select da listagem de grupos de componentes

[fix link](https://dev.azure.com/doocacom/Painel/_sprints/taskboard/Painel%20Team/Painel/Sprint%202?workitem=1378)

### Changes
- Ajuste visual