### PR TITLE
fix: card spacing

### DIFF
--- a/src/components/ui/card/Card.vue
+++ b/src/components/ui/card/Card.vue
@@ -94,7 +94,7 @@ watchEffect(() => (showBody.value = !props.dropdownClosed))
 						<slot name="caption" />
 					</span>
 				</div>
-				<div class="ui-card-header-content-button">
+				<div v-if="actions" class="ui-card-header-content-button">
 					<Link v-for="item in actions" :key="item.label" @click="item.onAction">
 						{{ item.label }}
 					</Link>


### PR DESCRIPTION
o header do card renderizava o gap mesmo quando desnecesseario por conta de um elemento que sempre aparecia, mesmo quando vazio; o elemento recebeu um if