### PR TITLE
[Fix] Bug na estilização do ícone no componente de Dropdown

### DIFF
--- a/src/components/ui/dropdown/Dropdown.scss
+++ b/src/components/ui/dropdown/Dropdown.scss
@@ -91,7 +91,7 @@
 				width: 100%;
 				cursor: pointer;
 
-				> .ui-icon {
+				> .ui-icon.leading-icon {
 					position: absolute;
 					background-color: #ffffff;
 					color: var(--primary);

--- a/src/components/ui/dropdown/DropdownItemButton.vue
+++ b/src/components/ui/dropdown/DropdownItemButton.vue
@@ -13,7 +13,7 @@ defineProps<{
 	<div class="ui-dropdown-item-wrapper">
 		<button class="ui-dropdown-item -button" type="button" :data-close="close" :class="class">
 			<slot>{{ label }}</slot>
-			<Icon :name="leadingIcon" v-if="leadingIcon" />
+			<Icon class="leading-icon" :name="leadingIcon" v-if="leadingIcon" />
 		</button>
 	</div>
 </template>


### PR DESCRIPTION
## [Fix] Bug na estilização do ícone no componente de Dropdown

[fix link](https://dev.azure.com/doocacom/Platform/_sprints/taskboard/squad-crm/Platform/CRM/sprint%206?workitem=6646)

### Changes
- Estilização separada do ícone caso seja o leading-icon recebido por prop