### PR TITLE
[Hotfix] Remoção do ícone da base de conhecimento

### DIFF
--- a/src/components/admin/page-helper-video/PageHelperVideo.vue
+++ b/src/components/admin/page-helper-video/PageHelperVideo.vue
@@ -3,14 +3,14 @@ import { ref } from 'vue'
 import Icon from '../../ui/icon/Icon.vue'
 import PageHelperVideoModal from './PageHelperVideoModal.vue'
 
-export interface VideoInterface {
+export interface IVideo {
 	name?: string
 	video_id?: boolean
 }
 
 const props = withDefaults(
 	defineProps<{
-		video?: VideoInterface
+		video?: IVideo
 	}>(),
 	{
 		video: () => ({})

--- a/src/components/admin/page-helper-video/PageHelperVideoModal.vue
+++ b/src/components/admin/page-helper-video/PageHelperVideoModal.vue
@@ -5,6 +5,17 @@ import Link from '../../ui/link/Link.vue'
 import AsideSection from '../../ui/aside/AsideSection.vue'
 import YoutubePlayer from '../../ui/youtube-player/YoutubePlayer.vue'
 
+withDefaults(
+	defineProps<{
+		title?: string
+		supportTitle?: string
+	}>(),
+	{
+		title: 'Base de conhecimento',
+		supportTitle: 'Para encontrar ainda mais informações, explore nossos artigos disponíveis na base de conhecimento.'
+	}
+)
+
 const video = ref<any>({})
 const aside = ref(false)
 
@@ -23,15 +34,20 @@ defineExpose({
 		<div class="page-helper-video-modal">
 			<AsideSection>
 				<div class="videoWrapper">
-					<YoutubePlayer :videoid="video.video_id" :width="480" :height="320" :controls="1" style="width: 100%" />
+					<YoutubePlayer :video-id="video.video_id" :width="480" :height="320" style="width: 100%" />
 				</div>
 			</AsideSection>
 			<AsideSection>
-				<a class="page-helper-video-link">
-					<img src="./knowledge.svg" class="svg-inverter" />
-				</a>
+				<div class="page-helper-video-title">
+					<div class="page-helper-video-default">
+						<h3 class="page-helper-video-default-title">{{ title }}</h3>
+						<p class="page-helper-video-default-support">
+							{{ supportTitle }}
+						</p>
+					</div>
+				</div>
 				<ul class="page-helper-video-modal-list">
-					<li v-for="item in video.articles">
+					<li v-for="item in video.articles" :key="item.url">
 						<Link :href="item.url" target="_blank">
 							{{ item.name }}
 						</Link>
@@ -60,12 +76,12 @@ defineExpose({
 		height: 100%;
 	}
 
-	.page-helper-video-link {
+	.page-helper-video-default {
 		margin: 0 0 20px;
 		display: inline-block;
 
-		img {
-			display: block;
+		&-support {
+			margin: 0;
 		}
 	}
 

--- a/src/components/admin/page/Page.vue
+++ b/src/components/admin/page/Page.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import Titlebar from '../titlebar/Titlebar.vue'
-import PageHelperVideo from '../page-helper-video/PageHelperVideo.vue'
 import PageMessageSupport from '../page-message-support/PageMessageSupport.vue'
+import PageHelperVideo, { type IVideo } from '../page-helper-video/PageHelperVideo.vue'
 import type { IAction } from '../../../types/IAction'
 
 export interface Props {
@@ -12,7 +12,7 @@ export interface Props {
 	to?: object
 	backlink?: object
 	size?: 'sm' | 'md' | 'lg' | 'full'
-	videoHelp?: any
+	videoHelp?: IVideo
 	footerHelp?: any
 	title?: string | null
 	groupActions?: {

--- a/src/components/ui/youtube-player/YoutubePlayer.vue
+++ b/src/components/ui/youtube-player/YoutubePlayer.vue
@@ -2,10 +2,9 @@
 import { onMounted, ref } from 'vue'
 
 const props = defineProps<{
-	videoid: string
+	videoId: string
 	width?: string | number
 	height?: string | number
-	controls: boolean
 }>()
 
 const player = ref()
@@ -16,7 +15,7 @@ function onYouTubeIframeAPIReady() {
 	player.value = new YT.Player('player', {
 		height: props.height || '360',
 		width: props.width || '640',
-		videoId: props.videoid,
+		videoId: props.videoId,
 		events: {
 			onReady: onPlayerReady
 		}


### PR DESCRIPTION
## Remoção do ícone da base de conhecimento

[task link](https://dev.azure.com/doocacom/Platform/_sprints/taskboard/squad-storefront/Platform/storefront/sprint%2013?workitem=6754)

### Changes:

- Remoção do ícone da base de conhecimento no componente `PageHelperVideoModal`
  - Adição das props `title` e `supportTitle` com textos default caso elas não forem passadas na utilização do componente