### PR TITLE
[Fix] Remover alterações de validação do PageHelperVideo 

### DIFF
--- a/src/components/admin/page-helper-video/PageHelperVideo.vue
+++ b/src/components/admin/page-helper-video/PageHelperVideo.vue
@@ -24,7 +24,7 @@ const onClick = () => {
 </script>
 
 <template>
-	<div class="ui-page-helper-video" v-if="video.name" @click="onClick">
+	<div class="ui-page-helper-video" v-if="video.video_id" @click="onClick">
 		<div class="ui-page-helper-video-message">
 			<Icon class="ui-page-helper-video-icon" name="play_circle" filled></Icon>
 			<span>

--- a/src/components/admin/page-helper-video/PageHelperVideoModal.vue
+++ b/src/components/admin/page-helper-video/PageHelperVideoModal.vue
@@ -32,7 +32,7 @@ defineExpose({
 <template>
 	<Aside v-model="aside" :title="video.title || 'Ajuda'" size="sm">
 		<div class="page-helper-video-modal">
-			<AsideSection v-if="video.video_id">
+			<AsideSection>
 				<div class="videoWrapper">
 					<YoutubePlayer :video-id="video.video_id" :width="480" :height="320" style="width: 100%" />
 				</div>


### PR DESCRIPTION
## [Fix] Remover alterações de validação do PageHelperVideo 

### Changes:

- Substituição da validação de nome do video por video_id
- Remoção da validação por video_id no modal do PageHelperVideo

obs: Essas alterações estão agora de volta ao seu estado original.