### PR TITLE
[Hotfix] Remover evento "duplicado" de keydown esc

### DIFF
--- a/src/components/ui/modal/Modal.vue
+++ b/src/components/ui/modal/Modal.vue
@@ -88,7 +88,6 @@ watchEffect(() => {
 		<div
 			v-if="modelValue"
 			:id="uid"
-			@keydown.esc="close()"
 			class="ui-modal"
 			:class="[
 				classList,


### PR DESCRIPTION
## [Hotfix] Remover evento "duplicado" de keydown esc

### Changes:

- Remoção do evento de esc keydown diretamente na div, esse evento conflitava com o addEventListener de keydown que disparava outra função para fechar o modal. 