### PR TITLE
[Hotfix] Adicionar mensagem customizada no modal de Delete do TableList

### DIFF
--- a/src/components/admin/table-list/table-list-nav-bulk/TableListNavBulk.vue
+++ b/src/components/admin/table-list/table-list-nav-bulk/TableListNavBulk.vue
@@ -47,7 +47,8 @@ const onRemoveDialog = () => {
 			if (props.config.dialogDelete.message.concatMessage) {
 				return `${defaultMessage} ${props.config.dialogDelete.message.text}`
 			} else return props.config.dialogDelete.message.text
-		} else defaultMessage
+		}
+		return defaultMessage
 	}
 
 	dialog.open({

--- a/src/components/admin/table-list/table-list-nav-bulk/TableListNavBulk.vue
+++ b/src/components/admin/table-list/table-list-nav-bulk/TableListNavBulk.vue
@@ -34,12 +34,27 @@ const checkbox = ref<boolean>(false)
 const onCheckAll = () => props.state.checkAll(!checkbox.value)
 const onRemoveDialog = () => {
 	const count = zerofill(props.selected.length, 2)
+	const defaultMessage = `Você confirma a exclusão de <b>${count}</b> ${pluralize(
+		count,
+		'registro selecionado',
+		'registros selecionados',
+		'',
+		false
+	)}?`
+
+	function buildMessage() {
+		if (props.config.dialogDelete?.message) {
+			if (props.config.dialogDelete.message.concatMessage) {
+				return `${defaultMessage} ${props.config.dialogDelete.message.text}`
+			} else return props.config.dialogDelete.message.text
+		} else defaultMessage
+	}
 
 	dialog.open({
-		title: 'Excluir registros',
-		destructIcon: 'delete',
-		destructLabel: `Deletar registros`,
-		message: `Você confirma a exclusão dos registros selecionados? <br><b>${count}</b> ${pluralize(count, 'selecionado', 'selecionados', '', false)}.`,
+		title: props.config.dialogDelete?.title ?? 'Excluir registros',
+		destructIcon: props.config.dialogDelete?.destructIcon ?? 'delete',
+		destructLabel: props.config.dialogDelete?.destructLabel ?? 'Deletar registros',
+		message: buildMessage(),
 		onCallback: remove
 	})
 }
@@ -106,8 +121,12 @@ onMounted(() => {
 				<Button size="sm" trailingIcon="unfold_more"> Ação em massa </Button>
 			</template>
 
-			<DropdownItemButton v-for="action in bulkActions" @click.stop="action.onAction(selected)" :key="action.label"
-				:variant="action.variant" :label="action.label" />
+			<DropdownItemButton
+				v-for="action in bulkActions"
+				@click.stop="action.onAction(selected)"
+				:key="action.label"
+				:variant="action.variant"
+				:label="action.label" />
 		</Dropdown>
 	</div>
 </template>

--- a/src/types/ITableListConfig.ts
+++ b/src/types/ITableListConfig.ts
@@ -1,10 +1,20 @@
-import type { IResourceService, TApiData } from 'src/types/IApiResource'
+import type { TApiData } from 'src/types/IApiResource'
 
 export type TBulkActions = Array<{
 	label: string
 	variant?: string
 	onAction(a: number[]): void
 }>
+
+export interface DialogDelete {
+	title?: string
+	destructIcon?: string
+	destructLabel?: string
+	message?: {
+		text: string
+		concatMessage?: boolean
+	}
+}
 
 export interface ITableListConfig {
 	service: any
@@ -24,4 +34,5 @@ export interface ITableListConfig {
 	actions?: string[]
 	placeholder?: string
 	omitFiltersValues?: string[]
+	dialogDelete?: DialogDelete
 }


### PR DESCRIPTION
## [Hotfix] Adicionar mensagem customizada no modal de Delete do TableList

###  Changes: 
- Adição da prop opcional `dialogDelete` de configuração no componente `TableList`, com ela é possível customizar os atributos de título, texto, label/ícone do botão da deleção de registros no TableList.