### PR TITLE
[Task] Adicionar parâmetro para substituir todas options no select

### DIFF
--- a/src/components/ui/form-autocomplete/FormAutocomplete.vue
+++ b/src/components/ui/form-autocomplete/FormAutocomplete.vue
@@ -139,9 +139,9 @@ onMounted(() => {
 })
 
 defineExpose({
-	setChoices(choices: any[]) {
+	setChoices(choices: any[], replaceOptions?: boolean) {
 		if (element.value) {
-			element.value.setChoices(choices)
+			element.value.setChoices(choices, undefined, undefined, replaceOptions)
 		}
 	}
 })


### PR DESCRIPTION
## [Task] Adicionar parâmetro para substituir todas options no select

### Changes:

- Adição do parâmetro opcional `replaceOptions` para fazer a substituição do array de opções do `FormAutocomplete`.