### PR TITLE
[Hotfix] Dropdown não fecha

### DIFF
--- a/src/components/ui/dropdown/Dropdown.vue
+++ b/src/components/ui/dropdown/Dropdown.vue
@@ -87,7 +87,11 @@ defineExpose({
 </script>
 
 <template>
-	<div class="ui-dropdown" :class="{ '-open': show, '-left': left, '-right': right, '-disbled': disabled }" :id="uid">
+	<div
+		@focusout="hide"
+		class="ui-dropdown"
+		:class="{ '-open': show, '-left': left, '-right': right, '-disbled': disabled }"
+		:id="uid">
 		<div class="ui-dropdown-button" @click="toggleDropdown">
 			<slot name="button-content" />
 		</div>


### PR DESCRIPTION
[Bug](https://dev.azure.com/doocacom/Platform/_sprints/taskboard/squad-storefront/Platform/storefront/sprint%2020?workitem=8708)

- Adiciona evento `focusout` com função hide no dropdown 