### PR TITLE
[Hotfix] Itens dentro do dropdown não tem a função de click executada.

### DIFF
--- a/src/components/ui/dropdown/Dropdown.vue
+++ b/src/components/ui/dropdown/Dropdown.vue
@@ -21,7 +21,7 @@ const listener = (e: MouseEvent | KeyboardEvent) => {
 	if (props.closeOn) hide()
 
 	if (e.target.dataset?.close != true) {
-		e.path.map((item: Element) => {
+		e.path?.map((item: Element) => {
 			if (item.className == 'ui-dropdown-menu') {
 				noClose = true
 			}
@@ -87,11 +87,7 @@ defineExpose({
 </script>
 
 <template>
-	<div
-		@focusout="hide"
-		class="ui-dropdown"
-		:class="{ '-open': show, '-left': left, '-right': right, '-disbled': disabled }"
-		:id="uid">
+	<div class="ui-dropdown" :class="{ '-open': show, '-left': left, '-right': right, '-disbled': disabled }" :id="uid">
 		<div class="ui-dropdown-button" @click="toggleDropdown">
 			<slot name="button-content" />
 		</div>


### PR DESCRIPTION
## Changes:

 - Adicionado o operador optional chaining no event do listener do click fora do dropdown.