### PR TITLE
[Hotfix] Prop de Config passando para o plugin easepick em FormDatepicker

### DIFF
--- a/src/components/ui/form-datepicker/FormDatepicker.vue
+++ b/src/components/ui/form-datepicker/FormDatepicker.vue
@@ -84,7 +84,8 @@ onMounted(() => {
 
 					update(dateFormat)
 				})
-			}
+			},
+			...props.config
 		}
 
 		if (props.range) {


### PR DESCRIPTION
Changes:

- A prop config do FormDatepicker passada como options para o easepick, dando a possibilidade de passar opções de forma livre para o plugin.