### PR TITLE
[Hotfix] Atualiza comportamento dos links no componente Page

### DIFF
--- a/src/components/admin/page-helper-articles/PageHelperArticles.stories.js
+++ b/src/components/admin/page-helper-articles/PageHelperArticles.stories.js
@@ -1,0 +1,34 @@
+import PageHelperArticles from './PageHelperArticles.vue'
+
+// More on default export: https://storybook.js.org/docs/vue/writing-stories/introduction#default-export
+export default {
+	title: 'Components/PageHelperArticles',
+	component: PageHelperArticles,
+	argTypes: {}
+}
+
+// More on component templates: https://storybook.js.org/docs/vue/writing-stories/introduction#using-args
+const Template = (args) => ({
+	components: { PageHelperArticles },
+	setup() {
+		return { args }
+	},
+	template: `
+    <PageHelperArticles v-bind="args"></PageHelperArticles>
+  `
+})
+
+export const Default = Template.bind({})
+Default.args = {
+	title: 'Seo & Rastreamento',
+	articles: [
+		{
+			name: 'Google Analytics',
+			url: 'https://ajuda.bagy.com.br/base-de-conhecimento-bagy/marketing/seo-e-rastreamento/google-analytics'
+		},
+		{
+			name: 'Google Search Console',
+			url: 'https://ajuda.bagy.com.br/base-de-conhecimento-bagy/marketing/seo-e-rastreamento/google-search-console'
+		}
+	]
+}

--- a/src/components/admin/page-helper-articles/PageHelperArticles.vue
+++ b/src/components/admin/page-helper-articles/PageHelperArticles.vue
@@ -22,6 +22,6 @@ const openArticleModal = () => {
 </script>
 
 <template>
-	<PageHelper :helper-name="title || 'esse item'" @clicked="openArticleModal" />
+	<PageHelper :helper-name="title || 'esse item'" @onClickLink="openArticleModal" />
 	<PageHelperArticleModal ref="pageHelperArticleModalRef" />
 </template>

--- a/src/components/admin/page-helper-articles/PageHelperArticles.vue
+++ b/src/components/admin/page-helper-articles/PageHelperArticles.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import PageHelper from '../page-helper/PageHelper.vue'
+import PageHelperArticleModal from '../page-helper-articles/PageHelperArticlesModal.vue'
+
+export interface IArticle {
+	name: string
+	url: string
+}
+
+export interface IArticlesHelper {
+	title?: string
+	articles?: IArticle[]
+}
+
+const props = defineProps<IArticlesHelper>()
+
+const pageHelperArticleModalRef = ref()
+const openArticleModal = () => {
+	pageHelperArticleModalRef.value.open({ title: props.title, articles: props.articles })
+}
+</script>
+
+<template>
+	<PageHelper :helper-name="title || 'esse item'" @clicked="openArticleModal" />
+	<PageHelperArticleModal ref="pageHelperArticleModalRef" />
+</template>

--- a/src/components/admin/page-helper-articles/PageHelperArticlesModal.vue
+++ b/src/components/admin/page-helper-articles/PageHelperArticlesModal.vue
@@ -4,17 +4,6 @@ import Aside from '../../ui/aside/Aside.vue'
 import Link from '../../ui/link/Link.vue'
 import type { IArticle, IArticlesHelper } from './PageHelperArticles.vue'
 
-withDefaults(
-	defineProps<{
-		title?: string
-		supportTitle?: string
-	}>(),
-	{
-		title: 'Base de conhecimento',
-		supportTitle: 'Para encontrar ainda mais informações, explore nossos artigos disponíveis na base de conhecimento.'
-	}
-)
-
 const aside = ref(false)
 const itemTitle = ref<string>('Ajuda')
 const helperArticles = ref<IArticle[]>()
@@ -31,14 +20,11 @@ defineExpose({
 </script>
 
 <template>
-	<Aside v-model="aside" :title="itemTitle" size="sm">
+	<Aside v-model="aside" title="Ajuda" size="sm">
 		<div class="page-helper-articles">
-			<div class="page-helper-articles-default">
-				<h3>{{ title }}</h3>
-				<p class="page-helper-articles-default-support">
-					{{ supportTitle }}
-				</p>
-			</div>
+			<p class="page-helper-articles-support">
+				Para encontrar ainda mais informações, explore nossos artigos disponíveis na base de conhecimento.
+			</p>
 			<ul class="page-helper-articles-list">
 				<li class="page-helper-articles-item" v-for="item in helperArticles" :key="item.url">
 					<Link :href="item.url" target="_blank">
@@ -51,13 +37,9 @@ defineExpose({
 </template>
 <style lang="scss">
 .page-helper-articles {
-	&-default {
+	&-support {
 		margin: 0 0 20px;
 		display: inline-block;
-
-		&-support {
-			margin: 0;
-		}
 	}
 
 	&-list {

--- a/src/components/admin/page-helper-articles/PageHelperArticlesModal.vue
+++ b/src/components/admin/page-helper-articles/PageHelperArticlesModal.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import Aside from '../../ui/aside/Aside.vue'
+import Link from '../../ui/link/Link.vue'
+import type { IArticle, IArticlesHelper } from './PageHelperArticles.vue'
+
+withDefaults(
+	defineProps<{
+		title?: string
+		supportTitle?: string
+	}>(),
+	{
+		title: 'Base de conhecimento',
+		supportTitle: 'Para encontrar ainda mais informações, explore nossos artigos disponíveis na base de conhecimento.'
+	}
+)
+
+const aside = ref(false)
+const itemTitle = ref<string>('Ajuda')
+const helperArticles = ref<IArticle[]>()
+
+const open = (item: IArticlesHelper) => {
+	helperArticles.value = item.articles
+	if (item.title) itemTitle.value = item.title
+	aside.value = true
+}
+
+defineExpose({
+	open
+})
+</script>
+
+<template>
+	<Aside v-model="aside" :title="itemTitle" size="sm">
+		<div class="page-helper-articles">
+			<div class="page-helper-articles-default">
+				<h3>{{ title }}</h3>
+				<p class="page-helper-articles-default-support">
+					{{ supportTitle }}
+				</p>
+			</div>
+			<ul class="page-helper-articles-list">
+				<li class="page-helper-articles-item" v-for="item in helperArticles" :key="item.url">
+					<Link :href="item.url" target="_blank">
+						{{ item.name }}
+					</Link>
+				</li>
+			</ul>
+		</div>
+	</Aside>
+</template>
+<style lang="scss">
+.page-helper-articles {
+	&-default {
+		margin: 0 0 20px;
+		display: inline-block;
+
+		&-support {
+			margin: 0;
+		}
+	}
+
+	&-list {
+		padding-left: 0;
+		list-style: none;
+	}
+
+	&-item {
+		padding: 10px 0;
+		margin: 0;
+		border-top: solid 1px var(--border-color);
+	}
+}
+</style>

--- a/src/components/admin/page-helper-video/PageHelperVideo.vue
+++ b/src/components/admin/page-helper-video/PageHelperVideo.vue
@@ -5,7 +5,11 @@ import PageHelperVideoModal from './PageHelperVideoModal.vue'
 
 export interface IVideo {
 	name?: string
-	video_id?: boolean
+	video_id?: string
+	articles?: {
+		name: string
+		url: string
+	}[]
 }
 
 const props = withDefaults(

--- a/src/components/admin/page-helper-video/PageHelperVideoModal.vue
+++ b/src/components/admin/page-helper-video/PageHelperVideoModal.vue
@@ -31,7 +31,7 @@ defineExpose({
 </script>
 
 <template>
-	<Aside v-model="aside" :title="video.name || 'Ajuda'" size="sm">
+	<Aside v-model="aside" title="Ajuda" size="sm">
 		<div class="page-helper-video-modal">
 			<AsideSection>
 				<div class="videoWrapper">

--- a/src/components/admin/page-helper-video/PageHelperVideoModal.vue
+++ b/src/components/admin/page-helper-video/PageHelperVideoModal.vue
@@ -4,6 +4,7 @@ import Aside from '../../ui/aside/Aside.vue'
 import Link from '../../ui/link/Link.vue'
 import AsideSection from '../../ui/aside/AsideSection.vue'
 import YoutubePlayer from '../../ui/youtube-player/YoutubePlayer.vue'
+import type { IVideo } from './PageHelperVideo.vue'
 
 withDefaults(
 	defineProps<{
@@ -16,10 +17,10 @@ withDefaults(
 	}
 )
 
-const video = ref<any>({})
+const video = ref<IVideo>({})
 const aside = ref(false)
 
-const open = (item: any) => {
+const open = (item: IVideo) => {
 	video.value = item
 	aside.value = true
 }
@@ -30,7 +31,7 @@ defineExpose({
 </script>
 
 <template>
-	<Aside v-model="aside" :title="video.title || 'Ajuda'" size="sm">
+	<Aside v-model="aside" :title="video.name || 'Ajuda'" size="sm">
 		<div class="page-helper-video-modal">
 			<AsideSection>
 				<div class="videoWrapper">

--- a/src/components/admin/page-helper/PageHelper.scss
+++ b/src/components/admin/page-helper/PageHelper.scss
@@ -15,5 +15,6 @@
 
 	.ui-page-helper-name:hover {
 		cursor: pointer;
+		color: var(--primary);
 	}
 }

--- a/src/components/admin/page-helper/PageHelper.scss
+++ b/src/components/admin/page-helper/PageHelper.scss
@@ -5,7 +5,8 @@
 	padding: 10px 15px;
 	margin-bottom: var(--grid-gutter-width);
 	border: solid 1px var(--border-color);
-	border-radius: 6px;
+	border-radius: var(--border-radius);
+	background-color: var(--bg-white);
 
 	> .ui-icon {
 		margin-right: 10px;

--- a/src/components/admin/page-helper/PageHelper.scss
+++ b/src/components/admin/page-helper/PageHelper.scss
@@ -13,7 +13,7 @@
 		color: var(--primary);
 	}
 
-	.ui-page-helper-name:hover {
+	&:hover {
 		cursor: pointer;
 		color: var(--primary);
 	}

--- a/src/components/admin/page-helper/PageHelper.stories.js
+++ b/src/components/admin/page-helper/PageHelper.stories.js
@@ -27,7 +27,8 @@ const Template = (args) => ({
 
 export const Default = Template.bind({})
 Default.args = {
-	title: 'Produtos'
+	helperName: 'Produtos',
+	helperLink: 'https://ajuda.bagy.com.br/base-de-conhecimento-bagy/produtos'
 }
 
 Default.decorators = [vueRouter()]

--- a/src/components/admin/page-helper/PageHelper.vue
+++ b/src/components/admin/page-helper/PageHelper.vue
@@ -14,7 +14,7 @@ const emit = defineEmits<{
 
 <template>
 	<div class="ui-page-helper">
-		<icon name="info" />
+		<icon name="info" filled />
 		<span>
 			<b>Precisa de ajuda?</b> Acesse o material sobre
 			<b v-if="!!helperLink">

--- a/src/components/admin/page-helper/PageHelper.vue
+++ b/src/components/admin/page-helper/PageHelper.vue
@@ -13,14 +13,14 @@ const emit = defineEmits<{
 </script>
 
 <template>
-	<div class="ui-page-helper">
+	<div class="ui-page-helper" @click="emit('onClickLink')">
 		<icon name="info" filled />
 		<span>
 			<b>Precisa de ajuda?</b> Acesse o material sobre
 			<b v-if="!!helperLink">
-				<a :href="helperLink" class="ui-page-helper-name" v-text="helperName" target="_blank" />
+				<a :href="helperLink" v-text="helperName" target="_blank" />
 			</b>
-			<b v-else class="ui-page-helper-name" @click="emit('onClickLink')"> {{ helperName }}</b>
+			<b v-else> {{ helperName }}</b>
 		</span>
 	</div>
 </template>

--- a/src/components/admin/page-helper/PageHelper.vue
+++ b/src/components/admin/page-helper/PageHelper.vue
@@ -8,7 +8,7 @@ export interface IPageHelper {
 
 defineProps<IPageHelper>()
 const emit = defineEmits<{
-	(event: 'clicked'): void
+	(event: 'onClickLink'): void
 }>()
 </script>
 
@@ -20,7 +20,7 @@ const emit = defineEmits<{
 			<b v-if="!!helperLink">
 				<a :href="helperLink" class="ui-page-helper-name" v-text="helperName" target="_blank" />
 			</b>
-			<b v-else class="ui-page-helper-name" @click="emit('clicked')"> {{ helperName }}</b>
+			<b v-else class="ui-page-helper-name" @click="emit('onClickLink')"> {{ helperName }}</b>
 		</span>
 	</div>
 </template>

--- a/src/components/admin/page-helper/PageHelper.vue
+++ b/src/components/admin/page-helper/PageHelper.vue
@@ -13,14 +13,14 @@ const emit = defineEmits<{
 </script>
 
 <template>
-	<div class="ui-page-helper" @click="emit('clicked')">
+	<div class="ui-page-helper">
 		<icon name="info" />
-		<span class="ui-page-helper-text">
+		<span>
 			<b>Precisa de ajuda?</b> Acesse o material sobre
 			<b v-if="!!helperLink">
 				<a :href="helperLink" class="ui-page-helper-name" v-text="helperName" target="_blank" />
 			</b>
-			<b v-else class="text-lowercase">{{ helperName }}</b>
+			<b v-else class="ui-page-helper-name" @click="emit('clicked')"> {{ helperName }}</b>
 		</span>
 	</div>
 </template>

--- a/src/components/admin/page-helper/PageHelper.vue
+++ b/src/components/admin/page-helper/PageHelper.vue
@@ -1,18 +1,26 @@
 <script setup lang="ts">
 import Icon from '../../ui/icon/Icon.vue'
 
-defineProps({
-	helperLink: String,
-	helperName: String
-})
+export interface IPageHelper {
+	helperName: string
+	helperLink?: string
+}
+
+defineProps<IPageHelper>()
+const emit = defineEmits<{
+	(event: 'clicked'): void
+}>()
 </script>
 
 <template>
-	<div class="ui-page-helper">
+	<div class="ui-page-helper" @click="emit('clicked')">
 		<icon name="info" />
 		<span class="ui-page-helper-text">
 			<b>Precisa de ajuda?</b> Acesse o material sobre
-			<b><a :href="helperLink" class="ui-page-helper-name" v-text="helperName" target="_blank" /></b>
+			<b v-if="!!helperLink">
+				<a :href="helperLink" class="ui-page-helper-name" v-text="helperName" target="_blank" />
+			</b>
+			<b v-else class="text-lowercase">{{ helperName }}</b>
 		</span>
 	</div>
 </template>

--- a/src/components/admin/page/Page.vue
+++ b/src/components/admin/page/Page.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import Titlebar from '../titlebar/Titlebar.vue'
 import PageMessageSupport from '../page-message-support/PageMessageSupport.vue'
 import PageHelperVideo, { type IVideo } from '../page-helper-video/PageHelperVideo.vue'
+import PageHelperArticles, { type IArticle, type IArticlesHelper } from '../page-helper-articles/PageHelperArticles.vue'
 import type { IAction } from '../../../types/IAction'
 
 export interface Props {
@@ -13,6 +14,7 @@ export interface Props {
 	backlink?: object
 	size?: 'sm' | 'md' | 'lg' | 'full'
 	videoHelp?: IVideo
+	articlesHelp?: IArticle[]
 	footerHelp?: any
 	title?: string | null
 	groupActions?: {
@@ -23,6 +25,20 @@ export interface Props {
 
 const props = defineProps<Props>()
 const classList = ref<string[]>([])
+
+const articlesHelp = computed<IArticlesHelper>(() => {
+	const articlesHelp = {
+		title: props?.title,
+		articles: [] as IArticle[]
+	}
+
+	if (props?.articlesHelp?.length) {
+		articlesHelp.articles = props.articlesHelp
+	}
+
+	articlesHelp.articles = props.videoHelp?.articles || []
+	return articlesHelp as IArticlesHelper
+})
 
 if (props.size) {
 	classList.value.push(`-${props.size}`)
@@ -36,7 +52,11 @@ if (props.size) {
 				<slot name="titlebar-subtitle" />
 			</template>
 		</Titlebar>
-		<PageHelperVideo v-if="videoHelp" :video="videoHelp" />
+		<PageHelperVideo v-if="videoHelp?.video_id" :video="videoHelp" />
+		<PageHelperArticles
+			v-if="!videoHelp?.video_id && !!articlesHelp?.articles?.length"
+			:articles="articlesHelp.articles"
+			:title="articlesHelp.title" />
 		<slot name="default" />
 		<PageMessageSupport v-if="footerHelp" :name="footerHelp.name" :link="footerHelp.link" />
 	</div>

--- a/src/components/admin/titlebar/Titlebar.vue
+++ b/src/components/admin/titlebar/Titlebar.vue
@@ -52,16 +52,18 @@ onUnmounted(() => {
 		</div>
 		<div class="titlebar-actions">
 			<div v-if="secondaryActions?.length" class="titlebar-actions-secondary">
-				<Button
-					v-if="secondaryActions?.length == 1"
-					v-for="(item, index) in secondaryActions"
-					:key="index"
-					:class="item.class"
-					variant="plain"
-					:label="getButtonLabel(item.label, item.leadingIcon)"
-					:to="item.to"
-					:leading-icon="item.leadingIcon"
-					@click="item.onAction" />
+				<template v-if="secondaryActions?.length == 1">
+					<Button
+						v-for="(item, index) in secondaryActions"
+						:key="index"
+						:class="item.class"
+						variant="plain"
+						:label="getButtonLabel(item.label, item.leadingIcon)"
+						:to="item.to"
+						:leading-icon="item.leadingIcon"
+						@click="item.onAction" />
+				</template>
+
 				<Dropdown v-else right>
 					<template #button-content>
 						<Button


### PR DESCRIPTION
## [Hotfix] Atualiza comportamento dos links no componente Page

## Task: https://dev.azure.com/doocacom/Platform/_sprints/taskboard/squad-storefront/Platform/storefront/sprint%2028?workitem=10437

## Changes:
- Cria componente `PageHelperArticles`
- Atualiza componente `Page` adicionando logica para renderizar `PageHelperArticles` quando `video_id` não for passado porem existe uma lista de `articles`
- Cria escopo para diretiva `v-if` no componente `TitleBar`
- Atualiza tipagem `IVideo`
- Adapta componente `PageHelper` de modo a ser possível utiliza-lo como parte do `PageHelperArticles` 