### PR TITLE
[fix] ui-divider está sem configs de dark mode

### DIFF
--- a/src/components/ui/divider/Divider.scss
+++ b/src/components/ui/divider/Divider.scss
@@ -1,3 +1,5 @@
+@import '../../../scss/mixins.scss';
+
 .ui-divider {
 	min-width: 100%;
 	border-width: var(--s-border-none);
@@ -8,5 +10,9 @@
 
 	&.-transparent {
 		background-color: transparent;
+	}
+
+	@include darkmode {
+		background-color: var(--s-color-background-dark);
 	}
 }


### PR DESCRIPTION
## [fix] ui-divider está sem configs de dark mode

[fix link](https://dev.azure.com/doocacom/Platform/_workitems/edit/11042)

### changes:

- corrigido cor do componente no dark mode