### PR TITLE
[fix] table-list-item não mostra o badge

### DIFF
--- a/src/components/ui/badge/Badge.vue
+++ b/src/components/ui/badge/Badge.vue
@@ -38,7 +38,7 @@ const badgeClassList = computed(() => {
 
 <template>
 	<span class="ui-badge" :class="badgeClassList">
-		{{ label }}
+		<slot>{{ label }}</slot>
 	</span>
 </template>
 


### PR DESCRIPTION
## [fix] table-list-item não mostra o badge

[fix link](https://dev.azure.com/doocacom/Platform/_workitems/edit/11110)

### changes:

- adicionado slot ao componente para permitir uso de conteudo sem a prop label explicita