### PR TITLE
[Hotfix] Paginação da TableList não sendo exibida no Safari

### DIFF
--- a/src/components/admin/table-list/table-list-nav/TableListNav.scss
+++ b/src/components/admin/table-list/table-list-nav/TableListNav.scss
@@ -3,10 +3,8 @@
 .table-list-nav {
 	position: sticky;
 	top: var(--layout-navbar-height);
-	z-index: 88;
 
 	.table-list-nav-wrapper {
-		z-index: 88;
 		border-bottom: solid 1px var(--primary);
 	}
 
@@ -16,7 +14,6 @@
 		display: flex;
 		background: #fff;
 		padding: 0;
-		z-index: 2;
 		align-items: center;
 		height: 80px;
 		padding: 0 15px;


### PR DESCRIPTION
## [Hotfix] Paginação da TableList não sendo exibida no Safari

### Changes:

- Remoção dos z-index do scss da sidebar, estavam sem efeito nenhum mas para o navegador Safari era um problema pois o elemento de paginação não era exibido por conta da hierarquia dos z-index, algo específico do Safari.
