### PR TITLE
[fix] nome da loja em overflow em elipse em "minha conta"

### DIFF
--- a/src/components/admin/user-profile-card/partials/UserButton.scss
+++ b/src/components/admin/user-profile-card/partials/UserButton.scss
@@ -31,6 +31,7 @@
 		color: var(--s-color-content-light);
 		text-transform: uppercase;
 		position: relative;
+		flex-shrink: 0;
 
 		img {
 			max-width: 100%;
@@ -45,6 +46,8 @@
 		justify-content: space-between;
 		line-height: var(--s-line-height-20);
 		text-align: left;
+		max-width: 100%;
+
 		.name {
 			display: block;
 			font-weight: bold;
@@ -53,6 +56,13 @@
 
 		&-info {
 			width: 100%;
+		}
+
+		&-caption {
+			text-overflow: ellipsis;
+			max-width: 120px;
+			overflow: hidden;
+			display: block;
 		}
 	}
 


### PR DESCRIPTION
## [fix] nome da loja em overflow em elipse em "minha conta"

[fix link](https://dev.azure.com/doocacom/Platform/_workitems/edit/11791)

### changes:

- adicionado elipse ao caption (nome da loja) da sidebar
- acionado tamanho maximo