### PR TITLE
[fix] ao scrollar a tela o card de usuário fica aparecendo no mobile

### DIFF
--- a/src/components/admin/sidebar/Sidebar.scss
+++ b/src/components/admin/sidebar/Sidebar.scss
@@ -5,7 +5,7 @@
 	position: fixed;
 	top: 0;
 	z-index: var(--s-index-very-high);
-	height: 100%;
+	height: 100vh;
 
 	> .ui-sidebar-wrapper {
 		min-width: var(--layout-sidebar-width);
@@ -309,7 +309,7 @@
 	}
 
 	@include mobile {
-		height: calc(100% - var(--s-spacing-huge));
+		height: calc(100vh - var(--s-spacing-huge));
 
 		> .ui-sidebar-wrapper {
 			width: 100vw;


### PR DESCRIPTION
## [fix] ao scrollar a tela o card de usuário fica aparecendo no mobile

[fix link](https://dev.azure.com/doocacom/Platform/_workitems/edit/11901)

### changes:

- corrigido tamanho da sidebar (isso fazia com que o position e o translate não ficassem precisos)