### PR TITLE
[fix] border-radius na imagem do avatar

### DIFF
--- a/src/components/admin/user-profile-card/partials/UserButton.scss
+++ b/src/components/admin/user-profile-card/partials/UserButton.scss
@@ -35,7 +35,7 @@
 
 		img {
 			max-width: 100%;
-			padding: 2px;
+			border-radius: var(--s-border-radius-pill);
 		}
 	}
 


### PR DESCRIPTION
## [fix] border-radius na imagem do avatar

[fix link](https://dev.azure.com/doocacom/Platform/_workitems/edit/12004)

### changes:

- corrigido radius da imagem da sidebar
- removido padding entre a borda e a imagem