### PR TITLE
[Hotfix] Correção do import do css inline no apexcharts do DesignSystem

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
 		"lodash-es": "^4.17.21",
 		"luxon": "^3.2.1",
 		"maska": "^2.1.8",
+		"patch-package": "^8.0.0",
 		"perfect-scrollbar": "^1.5.5",
+		"postinstall-postinstall": "^2.1.0",
 		"vue-currency-input": "^3.0.3",
 		"vue-router": "^4.1.6"
 	},

--- a/patches/apexcharts+3.47.0.patch
+++ b/patches/apexcharts+3.47.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/apexcharts/src/apexcharts.js b/node_modules/apexcharts/src/apexcharts.js
+index 1cf65d3..993df80 100644
+--- a/node_modules/apexcharts/src/apexcharts.js
++++ b/node_modules/apexcharts/src/apexcharts.js
+@@ -13,7 +13,7 @@ import YAxis from './modules/axes/YAxis'
+ import InitCtxVariables from './modules/helpers/InitCtxVariables'
+ import Destroy from './modules/helpers/Destroy'
+ import { addResizeListener, removeResizeListener } from './utils/Resize'
+-import apexCSS from './assets/apexcharts.css'
++import apexCSS from './assets/apexcharts.css?inline'
+ 
+ /**
+  *


### PR DESCRIPTION
## [Hotfix] Correção do import do css inlin

[task link](https://dev.azure.com/doocacom/Platform/_sprints/taskboard/squad-suite/Platform/suite/2024/sprint%203?workitem=12122)

Estava dando erro ao importar os componentes do DS usando o index.ts no admin-markenting.
'/node_modules/apexcharts/src/assets/apexcharts.css?v=dd13f3cb' does not provide an export named 'default' (at apexcharts.js?v=dd13f3cb:16:8)

### Changes:

- Alteração do import do css inline na lib do apexcharts para corrigir erro de import nomeado do css na versão mais nova do vue.
- Foi usado a lib [patch-package](https://github.com/ds300/patch-package) para não precisar criar um fork dessa lib, ela alterar apenas a linha desejada sem precisar perder as atualizações originais do pacote npm.



Ref.:
https://main.vitejs.dev/guide/migration.html#removed-deprecated-apis
Default exports of CSS files (e.g import style from './foo.css'): Use the ?inline query instead
