### PR TITLE
[Fix] Reatividade do title do componente Modal 

### DIFF
--- a/src/components/ui/modal/Modal.vue
+++ b/src/components/ui/modal/Modal.vue
@@ -26,7 +26,6 @@ const emit = defineEmits(['update:modelValue', 'close', 'open'])
 const slots = useSlots()
 const showDialog = ref(false)
 const classList = ref<string[]>([])
-const currentTitle = ref(props.title)
 const style = ref<{
 	maxWidth?: string
 }>({})
@@ -105,9 +104,7 @@ watchEffect(() => {
 				<div class="ui-modal-content">
 					<div class="ui-modal-header" v-if="!hideHeader">
 						<div class="ui-modal-header-wrapper">
-							<h4 class="ui-modal-title">
-								{{ currentTitle }}
-							</h4>
+							<h4 class="ui-modal-title">{{ title }}</h4>
 							<span v-if="caption" class="ui-modal-caption"> {{ caption }}</span>
 						</div>
 


### PR DESCRIPTION
## [Fix] Reatividade do title do componente Modal 

### Changes:

- Remoção da `ref` desnecessária removendo a reatividade da prop.
