### PR TITLE
[fix] ajustes visuais do painel de controle

### DIFF
--- a/src/components/admin/titlebar/Titlebar.scss
+++ b/src/components/admin/titlebar/Titlebar.scss
@@ -11,14 +11,19 @@
 		align-items: center;
 		gap: var(--s-spacing-x-small);
 		color: var(--s-color-content-default);
+		overflow: hidden;
+		padding-right: var(--s-spacing-x-small);
 
 		& &-title {
 			overflow: hidden;
 			text-overflow: ellipsis;
 			white-space: nowrap;
+
 			&-text {
 				font: var(--s-typography-heading-large);
 				margin: 0;
+				text-overflow: ellipsis;
+				overflow: hidden;
 			}
 
 			&.-mobile {
@@ -52,12 +57,9 @@
 
 		&-content {
 			flex: 1;
-			overflow: hidden;
 
 			&-title-text {
-				text-overflow: ellipsis;
 				white-space: nowrap;
-				overflow: hidden;
 			}
 		}
 	}

--- a/src/components/ui/badge/Badge.scss
+++ b/src/components/ui/badge/Badge.scss
@@ -53,6 +53,10 @@
 		}
 	}
 
+	&.-no-wrap {
+		text-wrap: nowrap;
+	}
+
 	&.-pill {
 		border-radius: var(--s-border-radius-large);
 	}

--- a/src/components/ui/badge/Badge.vue
+++ b/src/components/ui/badge/Badge.vue
@@ -1,9 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import type { Size, Variant } from '../../../types/Types'
-
-type BadgeSize = Size
-type BadgeVariant = Variant
+import type { Size } from '../../../types/Types'
 
 export interface BadgeProps {
 	label?: string | number

--- a/src/components/ui/badge/Badge.vue
+++ b/src/components/ui/badge/Badge.vue
@@ -9,6 +9,7 @@ export interface BadgeProps {
 	label?: string | number
 	pill?: boolean
 	size?: Size
+	noWrap?: boolean
 	variant?: 'highlight' | 'warning' | 'success' | 'critical' | 'default'
 }
 
@@ -17,23 +18,12 @@ const props = withDefaults(defineProps<BadgeProps>(), {
 	variant: 'default'
 })
 
-const badgeClassList = computed(() => {
-	let classes = []
-
-	if (props.pill) {
-		classes.push('-pill')
-	}
-
-	if (props.size) {
-		classes.push(`-size-${props.size}`)
-	}
-
-	if (props.variant) {
-		classes.push(`-variant-${props.variant}`)
-	}
-
-	return classes
-})
+const badgeClassList = computed(() => [
+	props.pill && '-pill',
+	props.size && `-size-${props.size}`,
+	props.variant && `-variant-${props.variant}`,
+	props.noWrap && '-no-wrap'
+])
 </script>
 
 <template>

--- a/src/components/ui/badge/Badge.vue
+++ b/src/components/ui/badge/Badge.vue
@@ -15,16 +15,16 @@ const props = withDefaults(defineProps<BadgeProps>(), {
 	variant: 'default'
 })
 
-const badgeClasses = computed(() => {
-	return [
+const badgeClassList = computed(() => {
+	const badgeClasses = [
 		props.pill && '-pill',
 		props.size && `-size-${props.size}`,
 		props.variant && `-variant-${props.variant}`,
 		props.noWrap && '-no-wrap'
 	]
-})
 
-const badgeClassList = badgeClasses.value.filter((badgeClass) => badgeClass)
+	return badgeClasses.filter((badgeClass) => badgeClass)
+})
 </script>
 
 <template>

--- a/src/components/ui/badge/Badge.vue
+++ b/src/components/ui/badge/Badge.vue
@@ -18,12 +18,16 @@ const props = withDefaults(defineProps<BadgeProps>(), {
 	variant: 'default'
 })
 
-const badgeClassList = computed(() => [
-	props.pill && '-pill',
-	props.size && `-size-${props.size}`,
-	props.variant && `-variant-${props.variant}`,
-	props.noWrap && '-no-wrap'
-])
+const badgeClasses = computed(() => {
+	return [
+		props.pill && '-pill',
+		props.size && `-size-${props.size}`,
+		props.variant && `-variant-${props.variant}`,
+		props.noWrap && '-no-wrap'
+	]
+})
+
+const badgeClassList = badgeClasses.value.filter((badgeClass) => badgeClass)
 </script>
 
 <template>

--- a/src/components/ui/card/Card.scss
+++ b/src/components/ui/card/Card.scss
@@ -284,10 +284,6 @@
 			display: none;
 		}
 
-		.ui-button.-link {
-			margin-right: calc(var(--s-spacing-xx-small) * -1);
-		}
-
 		> button,
 		> button:hover,
 		> button:focus,

--- a/src/components/ui/form-layout/FormLayoutItem.vue
+++ b/src/components/ui/form-layout/FormLayoutItem.vue
@@ -10,6 +10,8 @@ defineProps<{
 </template>
 
 <style lang="scss">
+@import '../../../scss/mixins.scss';
+
 .ui-form-layout-item {
 	display: flex;
 	gap: var(--s-spacing-x-small);
@@ -21,6 +23,10 @@ defineProps<{
 
 	+ .ui-form-layout-item {
 		margin-top: var(--s-spacing-x-small);
+
+		@include mobile {
+			flex-direction: column;
+		}
 	}
 
 	+ .ui-alert {

--- a/src/components/ui/grid/col/Col.scss
+++ b/src/components/ui/grid/col/Col.scss
@@ -17,7 +17,6 @@ $columns: 12;
 	width: auto;
 	max-width: 100%;
 	padding: 0 calc(var(--s-spacing-x-small) * 0.5);
-	// margin-top: var(--grid-gutter-width);
 }
 
 @for $i from 1 through $columns {
@@ -45,8 +44,6 @@ $columns: 12;
 		@include mobile {
 			flex: 0 0 calc(100% / (12 / $i));
 			min-width: calc(100% / (12 / $i));
-			// flex: 0 0 100%;
-			// max-width: 100%;
 		}
 	}
 

--- a/src/components/ui/grid/col/Col.scss
+++ b/src/components/ui/grid/col/Col.scss
@@ -5,8 +5,7 @@ $columns: 12;
 	flex-basis: 0;
 	flex-grow: 1;
 	max-width: 100%;
-	padding: 0 calc(var(--grid-gutter-width) * 0.5);
-	// margin-top: var(--grid-gutter-width);
+	padding: 0 calc(var(--s-spacing-x-small) * 0.5);
 
 	@include mobile {
 		flex-basis: auto;
@@ -17,7 +16,7 @@ $columns: 12;
 	flex: 0 0 auto;
 	width: auto;
 	max-width: 100%;
-	padding: 0 calc(var(--grid-gutter-width) * 0.5);
+	padding: 0 calc(var(--s-spacing-x-small) * 0.5);
 	// margin-top: var(--grid-gutter-width);
 }
 


### PR DESCRIPTION
## [fix] ajustes visuais do painel de controle

[fix link](https://dev.azure.com/doocacom/Platform/_workitems/edit/12638)

### changes:

- ajustado paddings de `Col`
- adicionado prop `noWrap` para `Badge`
- corrigido agrupamento dos campos no mobile
- removido margin negativa em link dentro de `Card`
- adicionado ellipsis no desktop para o nome do produto em seu detalhe