### PR TITLE
Separa os tipos do componente PageHelperVideo em outro arquivo

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
 		"start-server-and-test": "^1.14.0",
 		"storybook": "7.5.3",
 		"storybook-design-token": "3.0.0-beta.7",
-		"typescript": "~5.1.6",
+		"typescript": "^5.1.6",
 		"vite": "4.1.4",
 		"vitest": "^0.34.2",
 		"vue": "^3.2.47",

--- a/src/components/admin/page-helper-video/PageHelperVideo.vue
+++ b/src/components/admin/page-helper-video/PageHelperVideo.vue
@@ -1,16 +1,8 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-import Icon from '../../ui/icon/Icon.vue'
 import PageHelperVideoModal from './PageHelperVideoModal.vue'
-
-export interface IVideo {
-	video_id: string
-	name?: string
-	articles?: {
-		name: string
-		url: string
-	}[]
-}
+import Icon from '../../ui/icon/Icon.vue'
+import type { IVideo } from './types'
 
 const props = defineProps<{
 	video: IVideo

--- a/src/components/admin/page-helper-video/PageHelperVideoModal.vue
+++ b/src/components/admin/page-helper-video/PageHelperVideoModal.vue
@@ -4,7 +4,7 @@ import Aside from '../../ui/aside/Aside.vue'
 import Link from '../../ui/link/Link.vue'
 import AsideSection from '../../ui/aside/AsideSection.vue'
 import YoutubePlayer from '../../ui/youtube-player/YoutubePlayer.vue'
-import type { IVideo } from './PageHelperVideo.vue'
+import type { IVideo } from './types'
 
 withDefaults(
 	defineProps<{
@@ -17,7 +17,11 @@ withDefaults(
 	}
 )
 
-const video = ref<IVideo>({})
+const video = ref<IVideo>({
+	video_id: '_QzHQ3zxUS4',
+	name: 'PageHelperVideo'
+})
+
 const aside = ref(false)
 
 const open = (item: IVideo) => {
@@ -95,10 +99,10 @@ defineExpose({
 			border-top: var(--s-border-light);
 			margin: 0;
 
-		&:first-child {
-			padding-top: 0;
-			border: 0;
-		}
+			&:first-child {
+				padding-top: 0;
+				border: 0;
+			}
 		}
 	}
 }

--- a/src/components/admin/page-helper-video/index.ts
+++ b/src/components/admin/page-helper-video/index.ts
@@ -1,0 +1,2 @@
+export { default as PageHelperVideo } from './PageHelperVideo.vue'
+export { type IVideo } from './types'

--- a/src/components/admin/page-helper-video/types.ts
+++ b/src/components/admin/page-helper-video/types.ts
@@ -1,0 +1,8 @@
+export interface IVideo {
+	video_id: string
+	name?: string
+	articles?: {
+		name: string
+		url: string
+	}[]
+}

--- a/src/components/admin/page/Page.vue
+++ b/src/components/admin/page/Page.vue
@@ -2,7 +2,8 @@
 import { ref, computed } from 'vue'
 import Titlebar from '../titlebar/Titlebar.vue'
 import PageMessageSupport from '../page-message-support/PageMessageSupport.vue'
-import PageHelperVideo, { type IVideo } from '../page-helper-video/PageHelperVideo.vue'
+import PageHelperVideo from '../page-helper-video/PageHelperVideo.vue'
+import type { IVideo } from '../page-helper-video/types'
 import PageHelperArticles, { type IArticle, type IArticlesHelper } from '../page-helper-articles/PageHelperArticles.vue'
 import type { IAction } from '../../../types/IAction'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ export { default as TableListItem } from './components/admin/table-list/TableLis
 export { default as TableListTable } from './components/admin/table-list/table-list-table/TableListTable.vue'
 export { default as TableListEmptyMessage } from './components/admin/table-list/snippets/TableListEmptyMessage.vue'
 export { default as InfiniteScroll } from './components/ui/infinite-scroll/InfiniteScroll.vue'
-export { default as PageHelperVideo } from './components/admin/page-helper-video/PageHelperVideo.vue'
+export * from './components/admin/page-helper-video'
 export { default as PageMessageSupport } from './components/admin/page-message-support/PageMessageSupport.vue'
 export { default as PageHelper } from './components/admin/page-helper/PageHelper.vue'
 export { default as Page } from './components/admin/page/Page.vue'


### PR DESCRIPTION
Visando facilitar o reuso de código dos tipos do DS no projeto do Hub Marketplace, separa os tipos do componente `PageHelperVideo` em outro arquivo e o exporta junto com o componente na biblioteca, permitindo o uso.