### PR TITLE
[Release/HUB] Ajusta tipagem para as variants do Toast

### DIFF
--- a/src/components/ui/toast/Toast.stories.ts
+++ b/src/components/ui/toast/Toast.stories.ts
@@ -20,7 +20,7 @@ const meta = {
     },
     variant: {
       control: 'select',
-      options: ['default', 'highlight', 'warning', 'success', 'critical'],
+      options: ['default', 'success', 'critical', 'warning', 'highlight'],
     },
   },
 } satisfies Meta<typeof Toast>;
@@ -29,35 +29,35 @@ type Story = StoryObj<typeof meta>;
 
 export default meta;
 
-export const Default: Story = {
+export const minimum: Story = {
   args: {},
 };
 
-export const Closeable: Story = {
+export const closeable: Story = {
   args: {
     closeable: true,
   },
 };
 
-export const Highlight: Story = {
+export const highlight: Story = {
   args: {
     variant: 'highlight',
   },
 };
 
-export const Warning: Story = {
+export const warning: Story = {
   args: {
     variant: 'warning',
   },
 };
 
-export const Success: Story = {
+export const success: Story = {
   args: {
     variant: 'success',
   },
 };
 
-export const Critical: Story = {
+export const danger: Story = {
   args: {
     variant: 'critical',
   },

--- a/src/components/ui/toast/Toast.stories.ts
+++ b/src/components/ui/toast/Toast.stories.ts
@@ -57,7 +57,7 @@ export const success: Story = {
   },
 };
 
-export const danger: Story = {
+export const critical: Story = {
   args: {
     variant: 'critical',
   },

--- a/src/components/ui/toast/Toast.vue
+++ b/src/components/ui/toast/Toast.vue
@@ -8,8 +8,6 @@ const props = withDefaults(defineProps<ToastProps>(), {
   variant: 'default',
 });
 
-const styleClasses = ref<string[]>([]);
-
 const closed = ref(false);
 const state = reactive<StateInterface>({
   option: {},
@@ -17,18 +15,13 @@ const state = reactive<StateInterface>({
   timer: null,
 });
 
-const toastClassList = computed(() => {
-  if (props.variant) {
-    styleClasses.value.push(`-variant-${props.variant}`);
-  }
-
-  return styleClasses.value;
-});
+const animationClass = ref('');
+const variantClass = computed(() => `-variant-${props.variant}`);
 
 const close = () => {
   closed.value = true;
   state.timer = null;
-  toastClassList.value.push('-leave');
+  animationClass.value = '-leave';
   setTimeout(() => {
     state.showing = false;
   }, 300);
@@ -51,7 +44,7 @@ const startTimer = () => {
 </script>
 
 <template>
-  <div class="ui-toast" :class="toastClassList" v-if="state.showing">
+  <div v-if="state.showing" class="ui-toast" :class="[variantClass, animationClass]">
     <div class="ui-toast-body">
       <div v-html="message" />
     </div>

--- a/src/components/ui/toast/index.ts
+++ b/src/components/ui/toast/index.ts
@@ -1,3 +1,3 @@
 export { default as Toast } from './Toast.vue';
-export { Toast as $toast } from './toast';
+export { $toast } from './toast';
 export type { ToastProps, StateInterface } from './types';

--- a/src/components/ui/toast/index.ts
+++ b/src/components/ui/toast/index.ts
@@ -1,3 +1,3 @@
 export { default as Toast } from './Toast.vue';
 export { $toast } from './toast';
-export type { ToastProps, StateInterface } from './types';
+export type { ToastProps, StateInterface, ToastVariant } from './types';

--- a/src/components/ui/toast/toast.ts
+++ b/src/components/ui/toast/toast.ts
@@ -33,7 +33,7 @@ const open = (text: string, config: any = {}) => {
   document.body.appendChild(toastWrapper);
 };
 
-export const Toast = {
+export const $toast = {
   open: open,
   success(text: string) {
     open(text, { type: 'success' });

--- a/src/components/ui/toast/types.ts
+++ b/src/components/ui/toast/types.ts
@@ -1,4 +1,4 @@
-import type { Variant } from '../../../types';
+export type ToastVariant = 'default' | 'highlight' | 'success' | 'warning' | 'critical';
 
 export interface ToastProps {
   className?: string;
@@ -6,7 +6,7 @@ export interface ToastProps {
   duration?: number;
   id?: string;
   message?: string;
-  variant?: Variant | 'default';
+  variant?: ToastVariant;
 }
 
 export interface StateInterface {

--- a/src/types/general.ts
+++ b/src/types/general.ts
@@ -12,4 +12,5 @@ export type Spacing = 'xs' | 'sm' | 'default' | 'lg' | 'xl';
 
 export type Target = '_blank' | '_self';
 
+/** Tipo compartilhado entre componentes, validar alterações */
 export type Variant = 'primary' | 'success' | 'danger' | 'link' | 'plain' | 'default';


### PR DESCRIPTION
O Toast estava usando o type `Variant` compartilhado por múltiplos componentes no DS o que gerava problemas de tipagem, esse PR tem por objetivo alinhar a tipagem das variants com as cores disponibilizadas para o mesmo e efetuar os ajustes de tipagem e padrão de código necessários. Essas alteração não quebram o uso do componente.

### Changes:

**Toast**
- Cria um novo tipo exclusivo do Toast
- Ajusta problemas de lint dos arquivos de stories de documentação
- Troca a atribuição de classes para resolver problemas de lint, porporcionando a reatividade das mesmas

### Evidências:

![toast-storybook](https://github.com/user-attachments/assets/372f58de-c6b8-44a7-bffe-b6622ce41533)
