### PR TITLE
Corrige problema no BrowserSelectModal

### DIFF
--- a/src/components/admin/browser-select/BrowserSelectModal.vue
+++ b/src/components/admin/browser-select/BrowserSelectModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch, withDefaults } from 'vue';
+import { ref, toRaw, watch, withDefaults } from 'vue';
 import FormTextfield from '../../ui/form-textfield/FormTextfield.vue';
 import Icon from '../../ui/icon/Icon.vue';
 import Row from '../../ui/grid/row/Row.vue';
@@ -56,7 +56,7 @@ const onCheckOne = (item: TypeItem, e: MouseEvent | KeyboardEvent) => {
 };
 
 const pushOne = (item: TypeItem) => {
-  memoryList.value.push(structuredClone(item) as never);
+  memoryList.value.push(structuredClone(toRaw(item)) as never);
   if (props.selectOne) {
     ids.value = [item[props.identifier]];
     apply();
@@ -72,7 +72,7 @@ const pushOne = (item: TypeItem) => {
 };
 
 const load = async (context: IContext) => {
-  const newParams: any = structuredClone(params.value) as never;
+  const newParams: any = structuredClone(toRaw(params.value)) as never;
   newParams.q = term.value;
   const res = await props.service.get(newParams);
   params.value.page++;
@@ -130,7 +130,7 @@ const open = ({ searchBy, selectedIds }: any) => {
   resetParams();
 
   aside.value = true;
-  ids.value = structuredClone(selectedIds);
+  ids.value = structuredClone(toRaw(selectedIds));
   term.value = searchBy;
 };
 

--- a/src/components/ui/form-textfield/FormTextfield.vue
+++ b/src/components/ui/form-textfield/FormTextfield.vue
@@ -41,7 +41,7 @@ const update = (evt: Event) => {
 
 const maskRawValue = (evt: Event) => {
   const target = evt.target as HTMLInputElement;
-  if (props.modelValue == target.value.replace(/\.|-/g, '')) return;
+  if (props.modelValue === target.value.replace(/\.|-/g, '')) return;
   update(evt);
   emit('updateRaw', target.dataset.maskRawValue);
 };
@@ -87,8 +87,9 @@ const onClear = () => {
     :invalidFeedback="invalidFeedback"
     class="ui-form-textfield">
     <slot name="before" />
+    <!-- @vue-ignore -->
     <input
-      :v-maska="maskOptions"
+      v-maska:[maskOptions]
       class="form-control"
       :mask="mask"
       :data-maska-tokens="dataMaskaTokens"

--- a/src/components/ui/form-textfield/FormTextfield.vue
+++ b/src/components/ui/form-textfield/FormTextfield.vue
@@ -88,7 +88,7 @@ const onClear = () => {
     class="ui-form-textfield">
     <slot name="before" />
     <input
-      v-maska:[maskOptions]
+      :v-maska="maskOptions"
       class="form-control"
       :mask="mask"
       :data-maska-tokens="dataMaskaTokens"


### PR DESCRIPTION
Corrige um problema ao criar o clone do objeto via structuredClone passado devido a estrutura que o Vue cria para manter a reatividade. Adicionado tratativa toRaw nativa do Vue para recuperar o objeto original e continuar o fluxo.

Para ter mais detalhes, verificar o PR https://github.com/uxshop/design-system/pull/394 fechado devido mudança na nomenclatura da branch.