### PR TITLE
[4.x] - Ajusta problemas de lint e tipagem e altera variantes do Alert 

### DIFF
--- a/src/components/ui/alert/Alert.scss
+++ b/src/components/ui/alert/Alert.scss
@@ -45,7 +45,17 @@
     }
   }
 
-  &.-info {
+  &.-default {
+    background-color: var(--s-color-fill-default-light);
+    border-color: var(--s-color-border-default);
+    color: var(--s-color-content-default);
+
+    a:hover {
+      color: var(--s-color-content-default);
+    }
+  }
+
+  &.-highlight {
     background-color: var(--s-color-fill-highlight-light);
     border-color: var(--s-color-border-highlight);
     color: var(--s-color-content-highlight);

--- a/src/components/ui/alert/Alert.stories.ts
+++ b/src/components/ui/alert/Alert.stories.ts
@@ -19,7 +19,7 @@ const meta = {
       control: 'radio',
       options: [null, 'warning', 'error', 'check_circle'],
       description:
-        'Todos os ícones disponíveis podem ser encontrados em [Material Symbols](https://fonts.google.com/icons).',
+        'Todos os ícones disponíveis são os de estilo `Outlined` encontrados em [Material Symbols](https://fonts.google.com/icons).',
     },
     variant: {
       control: 'radio',

--- a/src/components/ui/alert/Alert.stories.ts
+++ b/src/components/ui/alert/Alert.stories.ts
@@ -2,11 +2,9 @@ import type { Meta, StoryObj } from '@storybook/vue3';
 
 import Alert from './Alert.vue';
 
-// More on how to set up stories at: https://storybook.js.org/docs/vue/writing-stories/introduction
 const meta = {
   title: 'Ui/Alert',
   component: Alert,
-  // This component will have an automatically generated docsPage entry: https://storybook.js.org/docs/vue/writing-docs/autodocs
   tags: ['autodocs'],
   args: {
     show: true,
@@ -17,39 +15,54 @@ const meta = {
     dismissible: false,
   },
   argTypes: {
+    icon: {
+      control: 'radio',
+      options: [null, 'warning', 'error', 'check_circle'],
+      description:
+        'Todos os ícones disponíveis podem ser encontrados em [Material Symbols](https://fonts.google.com/icons).',
+    },
     variant: {
-      control: 'select',
-      options: ['info', 'success', 'warning', 'danger'],
+      control: 'radio',
+      options: ['info', 'default', 'success', 'warning', 'danger', 'highlight'],
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Para visualizar as cores do componente reflitadas para cada organização, alterne a organização selecionada no topo.',
+      },
     },
   },
 } satisfies Meta<typeof Alert>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
-/*
- *👇 Render functions are a framework specific feature to allow you control on how the component renders.
- * See https://storybook.js.org/docs/vue/api/csf
- * to learn how to use render functions.
- */
-export const minimum: Story = {
-  args: {},
-};
 
-export const info: Story = {
+export const minimum: Story = {
   args: {
-    variant: 'info',
+    variant: 'default',
   },
 };
+
+export const highlight: Story = {
+  args: {
+    variant: 'highlight',
+  },
+};
+
 export const success: Story = {
   args: {
     variant: 'success',
   },
 };
+
 export const warning: Story = {
   args: {
     variant: 'warning',
   },
 };
+
 export const danger: Story = {
   args: {
     variant: 'danger',

--- a/src/components/ui/alert/Alert.stories.ts
+++ b/src/components/ui/alert/Alert.stories.ts
@@ -19,7 +19,7 @@ const meta = {
   argTypes: {
     variant: {
       control: 'select',
-      options: ['default', 'info', 'success', 'warning', 'danger'],
+      options: ['info', 'success', 'warning', 'danger'],
     },
   },
 } satisfies Meta<typeof Alert>;
@@ -31,26 +31,26 @@ type Story = StoryObj<typeof meta>;
  * See https://storybook.js.org/docs/vue/api/csf
  * to learn how to use render functions.
  */
-export const Default: Story = {
+export const minimum: Story = {
   args: {},
 };
 
-export const Info: Story = {
+export const info: Story = {
   args: {
     variant: 'info',
   },
 };
-export const Success: Story = {
+export const success: Story = {
   args: {
     variant: 'success',
   },
 };
-export const Warning: Story = {
+export const warning: Story = {
   args: {
     variant: 'warning',
   },
 };
-export const Danger: Story = {
+export const danger: Story = {
   args: {
     variant: 'danger',
   },

--- a/src/components/ui/alert/Alert.vue
+++ b/src/components/ui/alert/Alert.vue
@@ -1,11 +1,16 @@
 <script setup lang="ts">
-import { watchEffect, ref, computed } from 'vue';
+import { watchEffect, ref, computed, onBeforeMount } from 'vue';
 import Icon from '../icon/Icon.vue';
 import type { AlertProps } from './types';
 
-const props = defineProps<AlertProps>();
+const props = withDefaults(defineProps<AlertProps>(), {
+  show: false,
+  dismissible: false,
+  center: false,
+  variant: 'info',
+});
 const emit = defineEmits(['dismissed']);
-const open = ref(Boolean(props.show));
+const open = ref(false);
 
 const iconsByVariant: Record<string, string> = {
   success: 'check_circle',
@@ -18,23 +23,6 @@ const close = () => {
   emit('dismissed');
 };
 
-const styleClassList = computed(() => {
-  let classList = [];
-  if (props.variant) {
-    classList.push(`-${props.variant}`);
-  }
-
-  if (props.center) {
-    classList.push(`-center`);
-  }
-
-  if (props.dismissible) {
-    classList.push(`-dismissible`);
-  }
-
-  return classList;
-});
-
 const currentIcon = computed(() => {
   let icon = props.icon;
   if (!props.icon && props.variant) {
@@ -43,16 +31,27 @@ const currentIcon = computed(() => {
   return icon;
 });
 
+onBeforeMount(() => {
+  open.value = props.show;
+});
+
 watchEffect(() => {
   open.value = Boolean(props.show);
 });
 </script>
 
 <template>
-  <div v-if="open" class="ui-alert" :class="styleClassList">
+  <div
+    v-if="open"
+    class="ui-alert"
+    :class="{
+      '-dismissible': dismissible,
+      '-center': center,
+      [`-${variant}`]: true,
+    }">
     <Icon v-if="currentIcon" class="ui-alert-icon" filled :name="currentIcon" size="24" />
     <div class="ui-alert-content">
-      <h5 class="ui-alert-title" v-if="title">
+      <h5 v-if="title" class="ui-alert-title">
         {{ title }}
       </h5>
       <div class="ui-alert-text">

--- a/src/components/ui/alert/Alert.vue
+++ b/src/components/ui/alert/Alert.vue
@@ -7,15 +7,17 @@ const props = withDefaults(defineProps<AlertProps>(), {
   show: false,
   dismissible: false,
   center: false,
-  variant: 'info',
+  variant: 'default',
 });
 const emit = defineEmits(['dismissed']);
 const open = ref(false);
 
-const iconsByVariant: Record<string, string> = {
+const iconsByVariant: Record<string, string | null> = {
+  default: null,
   success: 'check_circle',
   danger: 'error',
   warning: 'warning',
+  highlight: 'info',
 };
 
 const close = () => {
@@ -25,7 +27,7 @@ const close = () => {
 
 const currentIcon = computed(() => {
   let icon = props.icon;
-  if (!props.icon && props.variant) {
+  if (!props.icon && props.icon !== null && props.variant && iconsByVariant[props.variant]) {
     icon = iconsByVariant[props.variant];
   }
   return icon;

--- a/src/components/ui/alert/index.ts
+++ b/src/components/ui/alert/index.ts
@@ -1,3 +1,3 @@
 export { default as Alert } from './Alert.vue';
 export { default as AlertTitle } from './AlertTitle.vue';
-export type { AlertProps } from './types';
+export type { AlertProps, AlertVariant } from './types';

--- a/src/components/ui/alert/types.ts
+++ b/src/components/ui/alert/types.ts
@@ -1,6 +1,8 @@
+export type AlertVariant = 'success' | 'danger' | 'info' | 'warning';
+
 export interface AlertProps {
   title?: string;
-  variant?: 'success' | 'danger' | 'info' | 'warning';
+  variant?: AlertVariant;
   icon?: string;
   dismissible?: boolean;
   show?: boolean;

--- a/src/components/ui/alert/types.ts
+++ b/src/components/ui/alert/types.ts
@@ -1,9 +1,9 @@
-export type AlertVariant = 'success' | 'danger' | 'info' | 'warning';
+export type AlertVariant = 'success' | 'danger' | 'default' | 'warning' | 'highlight';
 
 export interface AlertProps {
   title?: string;
   variant?: AlertVariant;
-  icon?: string;
+  icon?: string | null;
   dismissible?: boolean;
   show?: boolean;
   center?: boolean;


### PR DESCRIPTION
O Alert não possuia um tipo com as suas variantes, por isso foi criado um tipo para o mesmo e adicionadas correções necessárias para o lint do componente. Além disso o componente possuia algumas inconsistências em relação ao design definido para o mesmo, por isso foi adicionada uma nova variante ao componente. Essas alterações em sua maiora não quebram o uso do componente, porém caso o componente possua a variante `info` poderá obter erros de lint e ter uma cor diferente da anterior "porque será aplicado a variante base `default`".

### Changes:

- Ajustado stories da documentação conforme sugestões de lint
- Criado o type `AlertVariant`
- Corrigido atribuição da ref `open`
- Alterado binding de classes do componente
- Corrigido validação para definir ícones, o que permite trocar os ícones de qualquer variante de alerta ou deixar qualquer variant sem ícone passando a prop icon como `null`, caso seja desejável


### Breaking Changes:

- Alterado **variant** `info` pela `default`, ajustando para cores neutras em tons de cinza conforme design esperado


### Evidências

![alert-ds](https://github.com/user-attachments/assets/151f640c-8b52-4560-80dd-318e8cd1fd4e)

