### PR TITLE
Deprecia `vue-router` nos componentes do projeto

### DIFF
--- a/.github/workflows/release.action.yml
+++ b/.github/workflows/release.action.yml
@@ -19,7 +19,6 @@ jobs:
           scope: '@tray-tecnologia'
           cache: 'npm'
       - run: npm ci
-      - run: npm run build
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,14 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
   },
-  "eslint.codeActionsOnSave.rules": [
+  "eslint.options": {
+    "fixTypes": [
+      "problem",
+      "suggestion",
+      "layout"
+    ]
+  },
+  "eslint.codeActionsOnSave.rules": [    
     "sort/imports"
   ],
   "typescript.preferences.importModuleSpecifierEnding": "minimal",

--- a/env.d.ts
+++ b/env.d.ts
@@ -1,6 +1,4 @@
 /// <reference types="vite/client" />
-/// <reference types="youtube" />
 
 declare module 'tom-select/dist/js/tom-select.complete.min.js' {}
 declare module 'apexcharts/src/apexcharts.js';
-declare module 'youtube-player';

--- a/env.d.ts
+++ b/env.d.ts
@@ -2,3 +2,11 @@
 
 declare module 'tom-select/dist/js/tom-select.complete.min.js' {}
 declare module 'apexcharts/src/apexcharts.js';
+
+declare module 'youtube' {
+  import 'youtube';
+
+  export type Player = YT.Player;
+  export type PlayerOptions = YT.PlayerOptions;
+  export type PlayerEvent = YT.PlayerEvent;
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -30,7 +30,7 @@ export default [
     rules: {
       eqeqeq: 'error',
       '@typescript-eslint/naming-convention': [
-        'error',
+        'warn',
         {
           selector: 'default',
           format: ['camelCase'],
@@ -109,6 +109,17 @@ export default [
         },
       ],
       '@typescript-eslint/no-empty-object-type': 'off', // Permite interfaces com uso de extends apenas
+      'no-restricted-imports': [
+        'warn',
+        {
+          paths: [
+            {
+              name: 'vue-router',
+              message: 'Vue Router dependency is deprected and will be removed in next version.',
+            },
+          ],
+        },
+      ],
     },
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,12 @@
 {
-  "name": "design-system",
-  "version": "4.0.0-alpha",
+  "name": "@tray-tecnologia/design-system",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "design-system",
-      "version": "4.0.0-alpha",
-      "hasInstallScript": true,
+      "name": "@tray-tecnologia/design-system",
+      "version": "4.0.0",
       "dependencies": {
         "@codemirror/commands": "^6.6.2",
         "@codemirror/lang-css": "^6.3.0",
@@ -29,9 +28,7 @@
         "luxon": "^3.4.0",
         "maska": "^2.1.11",
         "perfect-scrollbar": "^1.5.5",
-        "vite-plugin-lib-inject-css": "^2.1.1",
-        "vue-currency-input": "^3.1.0",
-        "vue-router": "^4.4.5"
+        "vue-currency-input": "^3.1.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^19.5.0",
@@ -78,8 +75,10 @@
         "typescript": "^5.5.4",
         "typescript-eslint": "^8.7.0",
         "vite": "5.4.5",
+        "vite-plugin-lib-inject-css": "^2.1.1",
         "vitest": "^2.0.0",
         "vue": "^3.5.9",
+        "vue-router": "^4.1.6",
         "vue-tsc": "^2.0.0"
       },
       "engines": {
@@ -87,7 +86,8 @@
       },
       "peerDependencies": {
         "typescript": ">= 5.5.0 < 5.7.0",
-        "vue": ">= 3.4.29"
+        "vue": ">= 3.4.29",
+        "vue-router": ">= 4.1.6"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -115,6 +115,7 @@
       "version": "0.22.6",
       "resolved": "https://registry.npmjs.org/@ast-grep/napi/-/napi-0.22.6.tgz",
       "integrity": "sha512-kNF87HiI4omHC7VzyBZSvqOAXtMlSDRF2YX+O5ya0XKv/7/GYms1opLQ+BQ9twLLDj0WsSFX4MYg0TrinZTxTg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -137,6 +138,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -153,6 +155,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -169,6 +172,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -185,6 +189,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -201,6 +206,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -217,6 +223,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -233,6 +240,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -249,6 +257,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -703,7 +712,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.2.0.tgz",
       "integrity": "sha512-+imAQkHf7U/Rwvu0wk1XWgsP3WnpCWmK7B48f0XqSNzgk64+grljTKC7pnO/xBiEMUziF7vKRfbBnOQhg126qQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@codemirror/autocomplete": {
@@ -1532,6 +1541,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1548,6 +1558,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1564,6 +1575,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1580,6 +1592,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1596,6 +1609,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1612,6 +1626,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1628,6 +1643,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1644,6 +1660,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1660,6 +1677,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1676,6 +1694,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1692,6 +1711,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1708,6 +1728,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1724,6 +1745,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1740,6 +1762,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1756,6 +1779,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1772,6 +1796,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1788,6 +1813,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1804,6 +1830,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1837,6 +1864,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1853,6 +1881,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1869,6 +1898,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1885,6 +1915,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1901,6 +1932,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2208,7 +2240,7 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
       "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
@@ -2223,7 +2255,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -2233,7 +2265,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
       "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -2243,7 +2275,7 @@
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
       "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2261,7 +2293,7 @@
       "version": "0.3.25",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
       "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -2426,6 +2458,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2439,6 +2472,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2452,6 +2486,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2465,6 +2500,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2478,6 +2514,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2491,6 +2528,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2504,6 +2542,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2517,6 +2556,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2530,6 +2570,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2543,6 +2584,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2556,6 +2598,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2569,6 +2612,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2582,6 +2626,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2595,6 +2640,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2608,6 +2654,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2621,6 +2668,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3722,6 +3770,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/express": {
@@ -3835,7 +3884,7 @@
       "version": "20.16.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.5.tgz",
       "integrity": "sha512-VwYCweNo3ERajwy0IUlqqcyZ8/A7Zwa9ZP3MnENWcB11AejO+tLy3pu850goUW2FC/IJMdZUfKpX/yxL1gymCA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -4493,6 +4542,7 @@
       "version": "6.6.4",
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
       "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@vue/eslint-config-prettier": {
@@ -4837,7 +4887,7 @@
       "version": "8.12.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
       "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -4997,6 +5047,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -5319,6 +5370,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -5434,7 +5486,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -12208,7 +12260,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/buffer-builder/-/buffer-builder-0.2.0.tgz",
       "integrity": "sha512-7VPMEPuYznPSoR21NE1zvd2Xna6c/CloiZCfcMXR1Jny6PjX0N4Nsa38zcBFo/FMK+BlA+FLKbJCQ0i2yxp+Xg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT/X11"
     },
     "node_modules/buffer-crc32": {
@@ -12225,7 +12277,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -12394,6 +12446,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -12420,6 +12473,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -12632,7 +12686,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.5.2.tgz",
       "integrity": "sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -13615,6 +13669,7 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
       "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -14454,7 +14509,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -14716,6 +14771,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -15427,7 +15483,7 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
       "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -15546,6 +15602,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -15642,7 +15699,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -15677,7 +15734,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -15707,7 +15764,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -17685,7 +17742,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -18082,7 +18139,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -18802,6 +18859,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -19006,6 +19064,7 @@
       "version": "4.21.3",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.21.3.tgz",
       "integrity": "sha512-7sqRtBNnEbcBtMeRVc6VRsJMmpI+JU1z9VTvW8D4gXIYQFz0aLcsE6rRkyghZkLfEgUZgVvOG7A5CVz/VW5GIA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.5"
@@ -19072,7 +19131,7 @@
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -19110,6 +19169,7 @@
       "version": "1.78.0",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.78.0.tgz",
       "integrity": "sha512-AaIqGSrjo5lA2Yg7RvFZrlXDBCp3nV4XP73GrLGvdRWWwk+8H3l0SDvq/5bA4eF+0RFPLuWUk3E+P1U/YqnpsQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -19129,7 +19189,7 @@
       "version": "1.79.5",
       "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.79.5.tgz",
       "integrity": "sha512-QFdalnjGFkbNvb6/uQGmP4OIN+GQ5/R77eu0PsXduDB1YP5JW5DSWFVDAyK6l6C54P+3J3eXkjuPYC0mcwX+AA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0",
@@ -19176,6 +19236,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19192,6 +19253,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19208,6 +19270,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19224,6 +19287,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19240,6 +19304,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19256,6 +19321,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19272,6 +19338,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19288,6 +19355,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19304,6 +19372,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19320,6 +19389,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19336,6 +19406,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19352,6 +19423,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19368,6 +19440,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19384,6 +19457,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19400,6 +19474,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19416,6 +19491,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19432,6 +19508,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19448,6 +19525,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19464,6 +19542,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19480,6 +19559,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19493,7 +19573,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -19503,7 +19583,7 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -19790,7 +19870,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -19809,7 +19889,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -20968,7 +21048,7 @@
       "version": "5.32.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.32.0.tgz",
       "integrity": "sha512-v3Gtw3IzpBJ0ugkxEX8U0W6+TnPKRRCWGh1jC/iM/e3Ki5+qvO1L1EAZ56bZasc64aXHwRHNIQEzm6//i5cemQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "peer": true,
       "dependencies": {
@@ -21024,7 +21104,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -21191,7 +21271,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -21297,7 +21377,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-      "devOptional": true,
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsx": {
@@ -21853,7 +21933,7 @@
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -22063,7 +22143,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
       "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/vary": {
@@ -22095,6 +22175,7 @@
       "version": "5.4.5",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.5.tgz",
       "integrity": "sha512-pXqR0qtb2bTwLkev4SE3r4abCNioP3GkjvIDLlzziPpXtHgiJIjuKl+1GN6ESOT3wMjG3JTeARopj2SwYaHTOA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.21.3",
@@ -22176,6 +22257,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/vite-plugin-lib-inject-css/-/vite-plugin-lib-inject-css-2.1.1.tgz",
       "integrity": "sha512-RIMeVnqBK/8I0E9nnQWzws6pdj5ilRMPJSnXYb6nWxNR4EmDPnksnb/ACoR5Fy7QfzULqS4gtQMrjwnNCC9zoA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ast-grep/napi": "^0.22.3",
@@ -22495,9 +22577,10 @@
       }
     },
     "node_modules/vue-router": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.4.5.tgz",
-      "integrity": "sha512-4fKZygS8cH1yCyuabAXGUAsyi1b2/o/OKgu/RUb+znIYOxPRxdkytJEx+0wGcpBE1pX6vUgh5jwWOKRGvuA/7Q==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.0.tgz",
+      "integrity": "sha512-HDuk+PuH5monfNuY+ct49mNmkCRK4xJAV9Ts4z9UFc4rzdDnxQLyCMGGc8pKhZhHTVzfanpNwB/lwqevcBwI4w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/devtools-api": "^6.6.4"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tray-tecnologia/design-system",
   "description": "Conjunto de diretrizes, componentes e padrões visuais e de código.",
-  "version": "4.0.0-rc",
+  "version": "4.0.0",
   "type": "module",
   "engines": {
     "node": ">=20.10.0"
@@ -28,7 +28,8 @@
   },
   "peerDependencies": {
     "typescript": ">= 5.5.0 < 5.7.0",
-    "vue": ">= 3.4.29"
+    "vue": ">= 3.4.29",
+    "vue-router": ">= 4.1.6"
   },
   "dependencies": {
     "@codemirror/commands": "^6.6.2",
@@ -51,9 +52,7 @@
     "luxon": "^3.4.0",
     "maska": "^2.1.11",
     "perfect-scrollbar": "^1.5.5",
-    "vite-plugin-lib-inject-css": "^2.1.1",
-    "vue-currency-input": "^3.1.0",
-    "vue-router": "^4.4.5"
+    "vue-currency-input": "^3.1.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.5.0",
@@ -100,8 +99,10 @@
     "typescript": "^5.5.4",
     "typescript-eslint": "^8.7.0",
     "vite": "5.4.5",
+    "vite-plugin-lib-inject-css": "^2.1.1",
     "vitest": "^2.0.0",
     "vue": "^3.5.9",
+    "vue-router": "^4.1.6",
     "vue-tsc": "^2.0.0"
   },
   "sideEffects": [

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build",
     "storybook:sass:compile": "tsx .storybook/compile.ts",
-    "prepare": "husky"
+    "prepare": "husky",
+    "postinstall": "npm run build"
   },
   "peerDependencies": {
     "typescript": ">= 5.5.0 < 5.7.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tray-tecnologia/design-system",
   "description": "Conjunto de diretrizes, componentes e padrões visuais e de código.",
-  "version": "4.0.0",
+  "version": "4.0.0-rc.2",
   "type": "module",
   "engines": {
     "node": ">=20.10.0"

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,16 +1,7 @@
-<script setup lang="ts">
-import Page from './components/admin/page/Page.vue';
-import type { IAction } from './types';
-
-const action: IAction = {
-  label: 'Bagy',
-};
-</script>
+<script setup lang="ts"></script>
 
 <template>
-  <Page title="Bagy Design System" size="full" :primary-action="action">
-    <TextStyle variant="muted">Inicie seus testes por aqui...</TextStyle>
-  </Page>
+  <router-view />
 </template>
 
 <style lang="scss">

--- a/src/Page.vue
+++ b/src/Page.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import Page from './components/admin/page/Page.vue';
+import type { IAction } from './types';
+
+const action: IAction = {
+  label: 'Bagy',
+};
+</script>
+
+<template>
+  <Page title="Bagy Design System" size="full" :primary-action="action">
+    <TextStyle variant="muted">Inicie seus testes por aqui hahahahah...</TextStyle>
+  </Page>
+</template>

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,9 @@
 import { createApp } from 'vue';
 
 import App from './App.vue';
+import router from './routes';
 
 const app = createApp(App);
+
+app.use(router);
 app.mount('#app');

--- a/src/components/admin/sidebar/types.ts
+++ b/src/components/admin/sidebar/types.ts
@@ -5,7 +5,9 @@ export interface SideBarItem {
   isNew?: boolean;
   highlightedLabel?: string;
   isComingSoon?: boolean;
+  /** @deprecated Essa propriedade está depreciada e será removida em breve. Use o href no lugar ou trate via evento. */
   to?: string;
+  /** @deprecated Essa propriedade está depreciada e será removida em breve. Use o href no lugar ou trate via evento. */
   params?: any;
   href?: string;
   key?: string;

--- a/src/components/admin/table-list/TableList.vue
+++ b/src/components/admin/table-list/TableList.vue
@@ -10,7 +10,7 @@ export default {};
 
 <script setup lang="ts">
 import { onMounted, watch, ref, reactive, onBeforeMount, computed } from 'vue';
-import { union, clone, omit, concat, isEqual } from 'lodash-es';
+import { union, clone, omit, isEqual } from 'lodash-es';
 import { useRoute } from 'vue-router';
 import HistoryReplaceState from '../../../services/HistoryReplaceState';
 import LocalStorage from '../../../services/LocalStorage';
@@ -42,6 +42,7 @@ const emit = defineEmits<{
   (event: 'clickRow', i: any): void;
   (event: 'emptyData'): void;
   (event: 'deletedItem', deletedItemIds: number[]): number[];
+  (event: 'duplicatedItem', duplicatedItemIds: number[]): number[];
 }>();
 
 const tableListNavFilterRef = ref();
@@ -55,7 +56,10 @@ const queryParams = ref<TQueryParams>({});
 const route = useRoute();
 const loading = ref(false);
 const meta = ref({});
-const cfg = Object.assign({ actions: ['remove', 'active'], hideCheckbox: false, placeholder: '' }, props.config);
+const cfg = Object.assign(
+  { actions: ['duplicate', 'active', 'remove'], hideCheckbox: false, placeholder: '' },
+  props.config
+);
 const storageNameFilters = `adm_table_filters_${String(route.name)}`;
 const formError = ref<Record<string, string[]> | undefined>(undefined);
 const hasQueryParams = ref();
@@ -198,6 +202,10 @@ const assignDefaultQueryParams = () => {
   return Object.assign(clone(queryDefault), clone(useRoute().query)) as TQueryParams;
 };
 
+const onDuplicate = () => {
+  emit('duplicatedItem', selected.value);
+};
+
 onBeforeMount(() => {
   hasQueryParams.value = route.query.sort;
 });
@@ -287,9 +295,9 @@ defineExpose({
   <div v-else class="table-list" v-show="firstGet">
     <TableListTabs v-if="!props.config.hideTabsFilter" :state="state" />
     <TableListNav :loading="loading">
-      <TableListNavBulk :state="state" :selected="selected" :config="cfg" :rows="rows" />
+      <TableListNavBulk :state="state" :selected="selected" :config="cfg" :rows="rows" @duplicate="onDuplicate" />
       <TableListNavRefresh v-if="!isMobile()" :state="state" />
-      <TableListNavSearch @refresh="fetchData" :placeholder="cfg.placeholder" :state="state" />
+      <TableListNavSearch :placeholder="cfg.placeholder" @refresh="fetchData" :state="state" />
       <TableListNavCustomFilter
         v-if="config.customFilterService"
         :service="config.customFilterService"

--- a/src/components/admin/table-list/TableList.vue
+++ b/src/components/admin/table-list/TableList.vue
@@ -281,7 +281,7 @@ const state = reactive({
 
 defineExpose({
   unshiftItem: unshiftItem,
-  refresh: fetchData,
+  refresh: (forceTimestamp?: boolean) => fetchData(forceTimestamp),
   openFilterSidebar: () => tableListNavFilterRef.value.openFilterSidebar(),
 });
 </script>

--- a/src/components/admin/table-list/table-list-nav-bulk/TableListNavBulk.vue
+++ b/src/components/admin/table-list/table-list-nav-bulk/TableListNavBulk.vue
@@ -7,9 +7,18 @@ import FormCheckbox from '../../../ui/form-checkbox/FormCheckbox.vue';
 import Dropdown from '../../../ui/dropdown/Dropdown.vue';
 import Button from '../../../ui/button/Button.vue';
 import DropdownItemButton from '../../../ui/dropdown/DropdownItemButton.vue';
-import type { TableListNavBulkProps, TBulkActions } from '../types';
+import type { ITableListConfig, TBulkActions } from '../types';
 
-const props = withDefaults(defineProps<TableListNavBulkProps>(), {
+type Props = {
+  rows: unknown[];
+  selected: number[];
+  config: ITableListConfig;
+  state: any;
+};
+
+const emit = defineEmits(['duplicate']);
+
+const props = withDefaults(defineProps<Props>(), {
   selected: () => {
     return [];
   },
@@ -52,6 +61,10 @@ const onRemoveDialog = () => {
   });
 };
 
+const onDuplicate = () => {
+  emit('duplicate');
+};
+
 const remove = () => props.state.removeSelected();
 const active = () => props.state.toggleActiveSelected(true);
 const inactive = () => props.state.toggleActiveSelected(false);
@@ -89,6 +102,14 @@ onMounted(() => {
         label: 'Remover registros',
         variant: 'danger',
         onAction: onRemoveDialog,
+      });
+    }
+
+    if (props.config.allowDuplication && item == 'duplicate') {
+      bulkActions.value.push({
+        label: 'Duplicar registros',
+        variant: 'danger',
+        onAction: onDuplicate,
       });
     }
   });

--- a/src/components/admin/table-list/types.ts
+++ b/src/components/admin/table-list/types.ts
@@ -37,6 +37,7 @@ export interface ITableListConfig {
   dialogDelete?: TDialogDelete;
   hideTabsFilter?: boolean;
   hideButtonFilter?: boolean;
+  allowDuplication?: boolean;
 }
 
 export interface ITableListState {

--- a/src/components/admin/table/types.ts
+++ b/src/components/admin/table/types.ts
@@ -1,4 +1,5 @@
 export interface TableRowProps {
+  /** @deprecated Essa propriedade está depreciada e será removida em breve. Trate via evento. */
   to?: any;
   head?: boolean;
 }

--- a/src/components/ui/breadcrumb/types.ts
+++ b/src/components/ui/breadcrumb/types.ts
@@ -1,3 +1,4 @@
 export interface BreadcrumbItemProps {
+  /** @deprecated Essa propriedade está depreciada e será removida em breve. Trate via evento. */
   to: Record<string, unknown>;
 }

--- a/src/components/ui/button/types.ts
+++ b/src/components/ui/button/types.ts
@@ -9,6 +9,7 @@ export interface ButtonProps {
   href?: string;
   flush?: 'left' | 'right';
   block?: boolean;
+  /** @deprecated Essa propriedade está depreciada e será removida em breve. Use o href no lugar ou trate via evento. */
   to?: object;
   spinnerBorder?: number | string;
   type?: string;

--- a/src/components/ui/dropdown/types.ts
+++ b/src/components/ui/dropdown/types.ts
@@ -16,6 +16,7 @@ export type IDropdownItemButton = {
   iconFilled?: boolean;
   iconSize?: string;
   href?: string;
+  /** @deprecated Essa propriedade está depreciada e será removida em breve. Use o href no lugar ou trate via evento. */
   to?: object;
 };
 

--- a/src/components/ui/link/types.ts
+++ b/src/components/ui/link/types.ts
@@ -3,6 +3,7 @@ export interface LinkProps {
   external?: boolean;
   href?: string;
   label?: string;
+  /** @deprecated Essa propriedade está depreciada e será removida em breve. Use o href no lugar ou trate via evento. */
   to?: string | object;
   wrapText?: boolean;
 }

--- a/src/components/ui/youtube-player/YoutubePlayer.vue
+++ b/src/components/ui/youtube-player/YoutubePlayer.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue';
+import 'youtube';
 import type { YoutubePlayerProps } from './types';
 
 const props = defineProps<YoutubePlayerProps>();
 const player = ref();
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 (window as any).onYouTubeIframeAPIReady = onYouTubeIframeAPIReady;
 
 function onYouTubeIframeAPIReady() {
@@ -31,6 +33,7 @@ function addYoutubeScriptTag() {
 }
 
 onMounted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   if (!(window as any).onYTReady) addYoutubeScriptTag();
   else onYouTubeIframeAPIReady();
 });

--- a/src/components/ui/youtube-player/YoutubePlayer.vue
+++ b/src/components/ui/youtube-player/YoutubePlayer.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue';
-import 'youtube';
+import type { Player, PlayerEvent, PlayerOptions } from 'youtube';
 import type { YoutubePlayerProps } from './types';
 
 const props = defineProps<YoutubePlayerProps>();
@@ -10,17 +10,20 @@ const player = ref();
 (window as any).onYouTubeIframeAPIReady = onYouTubeIframeAPIReady;
 
 function onYouTubeIframeAPIReady() {
-  player.value = new YT.Player('player', {
+  const options: PlayerOptions = {
     height: props.height || '360',
     width: props.width || '640',
     videoId: props.videoId,
     events: {
       onReady: onPlayerReady,
     },
-  });
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  player.value = new (window as any).YT.Player('player', options) as Player;
 }
 
-function onPlayerReady(event: YT.PlayerEvent) {
+function onPlayerReady(event: PlayerEvent) {
   event.target.playVideo();
 }
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,0 +1,15 @@
+import { createRouter, createWebHistory } from 'vue-router';
+
+const page = () => import('./Page.vue');
+
+const router = createRouter({
+  history: createWebHistory(import.meta.env.BASE_URL),
+  routes: [
+    {
+      path: '/',
+      component: page,
+    },
+  ],
+});
+
+export default router;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -58,10 +58,11 @@ export default defineConfig({
     copyPublicDir: false,
     minify: false,
     rollupOptions: {
-      external: ['vue'],
+      external: ['vue', 'vue-router'],
       output: {
         globals: {
           vue: 'Vue',
+          'vue-router': 'VueRouter',
         },
         preserveModules: false,
         chunkFileNames: 'chunks/[name].[hash].js',


### PR DESCRIPTION
#### Descrição

O ponto principal dessa alteração é depreciar o uso do `vue-router` nos componentes do Design System, diminuindo dependência, aumentado a usabilidade e compatibilidade dos componentes. A remoção da biblioteca ainda não possui data para acontecer.

#### Alterações

- Alterado `vue-router ` como peer e dev dependency;
- Depreciado o  `vue-router` para uso nos componentes;
- Corrigido problema do `TableList` especificando `vue-router` como item externo no build;
- Adicionado regra ao eslint para alertar uso do `vue-router`;
- Modificado o uso da tipagem do Youtube Player para não impactar projetos que usam o DS;

_Obs: Nenhuma alteração gera incompatibilidade com atuais implementações._