### PR TITLE
[v4.x] Remove o script de `postinstall`

### DIFF
--- a/.github/workflows/release.action.yml
+++ b/.github/workflows/release.action.yml
@@ -19,6 +19,7 @@ jobs:
           scope: '@tray-tecnologia'
           cache: 'npm'
       - run: npm ci
+      - run: npm run build
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tray-tecnologia/design-system",
-  "version": "4.0.0",
+  "version": "4.0.0-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tray-tecnologia/design-system",
-      "version": "4.0.0",
+      "version": "4.0.0-rc.3",
       "dependencies": {
         "@codemirror/commands": "^6.6.2",
         "@codemirror/lang-css": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tray-tecnologia/design-system",
   "description": "Conjunto de diretrizes, componentes e padrões visuais e de código.",
-  "version": "4.0.0-rc.2",
+  "version": "4.0.0-rc.3",
   "type": "module",
   "engines": {
     "node": ">=20.10.0"
@@ -24,8 +24,7 @@
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build",
     "storybook:sass:compile": "tsx .storybook/compile.ts",
-    "prepare": "husky",
-    "postinstall": "npm run build"
+    "prepare": "husky"
   },
   "peerDependencies": {
     "typescript": ">= 5.5.0 < 5.7.0",


### PR DESCRIPTION
### Descrição

Esse alteração remove o script de postinstall. Anteriormente mantivemos o script para facilitar o desenvolvimento do DS  e avanço de funcionalidade em testes internos, contudo isso gerava problema ao tentar realizar a instalação do pacote como dependência em outros projetos.