### PR TITLE
Micro ajustes gerais

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -2,11 +2,3 @@
 
 declare module 'tom-select/dist/js/tom-select.complete.min.js' {}
 declare module 'apexcharts/src/apexcharts.js';
-
-declare module 'youtube' {
-  import 'youtube';
-
-  export type Player = YT.Player;
-  export type PlayerOptions = YT.PlayerOptions;
-  export type PlayerEvent = YT.PlayerEvent;
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tray-tecnologia/design-system",
-  "version": "4.0.0-rc.3",
+  "version": "4.0.0-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tray-tecnologia/design-system",
-      "version": "4.0.0-rc.3",
+      "version": "4.0.0-rc.4",
       "dependencies": {
         "@codemirror/commands": "^6.6.2",
         "@codemirror/lang-css": "^6.3.0",
@@ -48,7 +48,6 @@
         "@types/lodash-es": "^4.17.12",
         "@types/luxon": "^3.4.0",
         "@types/node": "^20.0.0",
-        "@types/youtube": "^0.1.0",
         "@vitejs/plugin-vue": "5.1.3",
         "@vitejs/plugin-vue-jsx": "^4.0.1",
         "@vitest/coverage-v8": "^2.1.1",
@@ -3990,13 +3989,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/youtube": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@types/youtube/-/youtube-0.1.0.tgz",
-      "integrity": "sha512-Pg33m3X2mFgdmhtvzOlAfUfgOa3341N3/2JCrVY/mXVxb4hagcqqEG6w4vGCfB64StQNWHSj/T8Eotb1Rko/FQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.7.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tray-tecnologia/design-system",
   "description": "Conjunto de diretrizes, componentes e padrões visuais e de código.",
-  "version": "4.0.0-rc.3",
+  "version": "4.0.0-rc.4",
   "type": "module",
   "engines": {
     "node": ">=20.10.0"
@@ -72,7 +72,6 @@
     "@types/lodash-es": "^4.17.12",
     "@types/luxon": "^3.4.0",
     "@types/node": "^20.0.0",
-    "@types/youtube": "^0.1.0",
     "@vitejs/plugin-vue": "5.1.3",
     "@vitejs/plugin-vue-jsx": "^4.0.1",
     "@vitest/coverage-v8": "^2.1.1",

--- a/src/components/admin/page/Page.vue
+++ b/src/components/admin/page/Page.vue
@@ -5,7 +5,8 @@ import PageMessageSupport from '../page-message-support/PageMessageSupport.vue';
 import PageHelperVideo from '../page-helper-video/PageHelperVideo.vue';
 
 import type { PageProps } from './types';
-import type { PageHelperArticles, IArticle, PageHelperArticlesProps } from '../page-helper-articles';
+import { PageHelperArticles } from '../page-helper-articles';
+import type { IArticle, PageHelperArticlesProps } from '../page-helper-articles';
 
 const props = defineProps<PageProps>();
 const classList = ref<string[]>([]);

--- a/src/components/ui/tab/types.ts
+++ b/src/components/ui/tab/types.ts
@@ -5,7 +5,7 @@ export interface TabProviderInterface {
 }
 
 export interface TabProps {
-  modelValue: string;
+  modelValue: number | string;
 }
 
 export interface TabItemProps {

--- a/src/components/ui/youtube-player/YoutubePlayer.vue
+++ b/src/components/ui/youtube-player/YoutubePlayer.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue';
-import type { Player, PlayerEvent, PlayerOptions } from 'youtube';
 import type { YoutubePlayerProps } from './types';
 
 const props = defineProps<YoutubePlayerProps>();
@@ -10,7 +9,7 @@ const player = ref();
 (window as any).onYouTubeIframeAPIReady = onYouTubeIframeAPIReady;
 
 function onYouTubeIframeAPIReady() {
-  const options: PlayerOptions = {
+  const options = {
     height: props.height || '360',
     width: props.width || '640',
     videoId: props.videoId,
@@ -20,10 +19,11 @@ function onYouTubeIframeAPIReady() {
   };
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  player.value = new (window as any).YT.Player('player', options) as Player;
+  player.value = new (window as any).YT.Player('player', options);
 }
 
-function onPlayerReady(event: PlayerEvent) {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function onPlayerReady(event: any) {
   event.target.playVideo();
 }
 


### PR DESCRIPTION
### Descrição

- Alterado os tipos internos do componente `Tab` para igualar a propriedade passada evitando incompatibilidades;
- Removido`@types/youtube` que quebravam a checagem de tipos em projetos usando o DS;
- Corrigido importação do componente `PageHelperArticles` que antes estava sendo importado como tipo;