### PR TITLE
[4.x] Aumenta versão mínima node e lança versão 4.0.0 final 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ out
 build
 dist
 dist-ssr
+dist-storybook
 
 # Logs
 logs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tray-tecnologia/design-system",
-  "version": "4.0.0-rc.9",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tray-tecnologia/design-system",
-      "version": "4.0.0-rc.9",
+      "version": "4.0.0",
       "dependencies": {
         "@codemirror/commands": "^6.6.2",
         "@codemirror/lang-css": "^6.3.0",
@@ -79,7 +79,7 @@
         "vue-tsc": "^2.0.0"
       },
       "engines": {
-        "node": ">=20.10.0"
+        "node": ">=22.11.0"
       },
       "peerDependencies": {
         "typescript": ">= 5.5.0 < 5.7.0",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@tray-tecnologia/design-system",
   "description": "Conjunto de diretrizes, componentes e padrões visuais e de código.",
-  "version": "4.0.0-rc.9",
+  "version": "4.0.0",
   "type": "module",
   "engines": {
-    "node": ">=20.10.0"
+    "node": ">=22.11.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Descrição

O objetivo é majorar a versão mínima exigida pelo Design System para a atual versão LTS do NodeJs e gerar a release final 4.0.0. Nenhuma incompatibilidade entre a versão 20 e 22 do Node foi encontrado até o momento da abertura desse PR.