### PR TITLE
[Fix] Ajuste na documentação do DropFiles e FormColorPicker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tray-tecnologia/design-system",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tray-tecnologia/design-system",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "dependencies": {
         "@codemirror/commands": "^6.6.2",
         "@codemirror/lang-css": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tray-tecnologia/design-system",
   "description": "Conjunto de diretrizes, componentes e padrões visuais e de código.",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "type": "module",
   "engines": {
     "node": ">=22.11.0"

--- a/src/components/ui/aside/Aside.scss
+++ b/src/components/ui/aside/Aside.scss
@@ -1,5 +1,9 @@
 @import '../../../scss/mixins.scss';
 
+.aside-body-overflow {
+  overflow: hidden;
+}
+
 .ui-aside {
   position: fixed;
   z-index: var(--s-index-very-high);

--- a/src/components/ui/aside/Aside.vue
+++ b/src/components/ui/aside/Aside.vue
@@ -54,8 +54,10 @@ const listener = (e: { key: string }) => {
 
 watchEffect(() => {
   if (props.modelValue) {
+    document.body.classList.add('aside-body-overflow');
     open();
   } else {
+    document.body.classList.remove('aside-body-overflow');
     close();
   }
 });

--- a/src/components/ui/drop-files/DropFiles.stories.ts
+++ b/src/components/ui/drop-files/DropFiles.stories.ts
@@ -5,10 +5,10 @@ import DropFiles from './DropFiles.vue';
 import type { Meta, StoryObj } from '@storybook/vue3';
 import ImageTest from './__mocks__/image-drop-files-test.jpg';
 import DogImage from './__mocks__/dog-drop-files-test.jpg';
-import ExampleText from './__mocks__/example.txt';
 import { createLocalFile } from './__mocks__/createLocalFile';
 import { completeDropFilesActions } from './__mocks__/completeDropFilesActions';
 import { configWithFile } from './__mocks__/configWithFile';
+import { createMockFile } from './__mocks__/createMockFile';
 
 const templateDropFiles = /* html */ `
 <div style="max-width: 400px;">
@@ -126,9 +126,8 @@ export const withFile: Story = {
   render: (args: any) => ({
     components: { DropFiles },
     setup() {
-      createLocalFile(ExampleText).then((file: File) => {
-        args.file = file;
-      });
+      const file = createMockFile({ name: 'example.txt', size: 1024, type: 'text/plain' });
+      args.file = file;
 
       return { args };
     },
@@ -144,9 +143,8 @@ export const withFileAndCustomClass: Story = {
   render: (args: any) => ({
     components: { DropFiles },
     setup() {
-      createLocalFile(ExampleText).then((file: File) => {
-        args.file = file;
-      });
+      const file = createMockFile({ name: 'example.txt', size: 1024, type: 'text/plain' });
+      args.file = file;
 
       return { args };
     },

--- a/src/components/ui/drop-files/__mocks__/configWithFile.ts
+++ b/src/components/ui/drop-files/__mocks__/configWithFile.ts
@@ -3,7 +3,7 @@ import type { DropFilesProps } from '#ds/index';
 const size24MB = 24 * 1024 * 1024;
 
 export const configWithFile: DropFilesProps = {
-  allowedFormats: ['.txt'],
+  allowedFormats: ['text/plain'],
   maxFileSize: size24MB,
   label: 'Documento de texto para importar',
   subtitle: 'TXT com até 24MB',

--- a/src/components/ui/drop-files/__mocks__/example.txt
+++ b/src/components/ui/drop-files/__mocks__/example.txt
@@ -1,1 +1,0 @@
-Hello world!

--- a/src/components/ui/form-colorpicker/FormColorpicker.stories.ts
+++ b/src/components/ui/form-colorpicker/FormColorpicker.stories.ts
@@ -5,8 +5,16 @@ import type { Meta, StoryObj } from '@storybook/vue3';
 const meta: Meta<typeof FormColorpicker> = {
   title: 'Ui/Form/FormColorpicker',
   component: FormColorpicker,
+  render: (args) => ({
+    components: { FormColorpicker },
+    setup() {
+      return { args };
+    },
+    template: /* html */ `<FormColorpicker v-bind="args" v-model="args.modelValue" />`,
+  }),
   tags: ['autodocs'],
   args: {
+    modelValue: '',
     label: 'label',
     placeholder: 'placeholder',
   },
@@ -16,8 +24,9 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
-export const WithInput: Story = {
+export const minimum: Story = {};
+
+export const withInput: Story = {
   args: {
     withInput: true,
   },

--- a/src/components/ui/form-colorpicker/FormColorpicker.vue
+++ b/src/components/ui/form-colorpicker/FormColorpicker.vue
@@ -114,7 +114,11 @@ onMounted(() => {
 });
 
 watchPostEffect(() => {
-  if (pickr.value && props.modelValue != undefined && pickr.value.getColor().toHEXA().toString() != props.modelValue) {
+  if (
+    pickr.value &&
+    props.modelValue !== undefined &&
+    pickr.value.getColor().toHEXA().toString() !== props.modelValue
+  ) {
     pickr.value.setColor(props.modelValue);
   }
 
@@ -137,7 +141,7 @@ defineExpose({
   <label class="ui-colorpicker" :style="customStyle">
     <FormLabel class="ui-colorpicker" :label="label" @click="pickr.show()" />
     <div class="ui-colorpicker-content">
-      <div class="pickr" :id="uid"></div>
+      <div :id="uid" class="pickr"></div>
       <input
         v-if="withInput"
         class="form-control"


### PR DESCRIPTION
Foi identificado que a documentação dos componentes **DropFiles** e **FormColorPicker** possuiam alguns problemas, sendo que no DropFiles o arquivo da storie `WithFile` quebrava devido ao build do storybook perder sua referência e o FormColorPicker não refletia a modificação das cores selecionadas no storie `WithInput` devido a ausência do modelValue como argumento. Além disso foi identificada a necessidade de corrigir o comportamento do Aside que exibia scroll duplo ao abrir o componente em uma página já com scroll ativo.

### Changes:

- **ui/Aside:** melhoria no estilo que oculta o scroll do body quando o componente está aberto.
- **ui/DropFiles:** melhoria na documentação.
- **ui/FormColorPicker:** melhoria na documentação.

### Evidências

![evidencias-github](https://github.com/user-attachments/assets/520aeabd-1d62-46aa-a056-df30208159eb)
