### PR TITLE
[Fix] Ajuste no DropFiles para corrigir update e no FormColorPicker para remover instâncias ao desmontar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tray-tecnologia/design-system",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tray-tecnologia/design-system",
-      "version": "4.2.1",
+      "version": "4.2.2",
       "dependencies": {
         "@codemirror/commands": "^6.6.2",
         "@codemirror/lang-css": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tray-tecnologia/design-system",
   "description": "Conjunto de diretrizes, componentes e padrões visuais e de código.",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "type": "module",
   "engines": {
     "node": ">=22.11.0"

--- a/src/components/ui/drop-files/DropFiles.stories.ts
+++ b/src/components/ui/drop-files/DropFiles.stories.ts
@@ -105,16 +105,20 @@ export const changeImages: Story = {
       });
 
       setTimeout(() => {
+        args.file = null;
+      }, 3000);
+
+      setTimeout(() => {
         createLocalFile(DogImage).then((file: File) => {
           args.file = file;
         });
-      }, 3000);
+      }, 6000);
 
       return { args };
     },
     template:
       templateDropFiles +
-      '<b style="display: block; margin-top: 20px; background: #a9a9a92b; border-radius: 30px; width: fit-content; padding: 10px;">Observe que a imagem será alterada em 3 segundos!</b>',
+      '<b style="display: block; margin-top: 20px; background: #a9a9a92b; border-radius: 30px; width: fit-content; padding: 10px;">Observe que a imagem será removida em 3 segundos e alterada em 6 segundos!</b>',
   }),
   args: {
     ...configWithImage,

--- a/src/components/ui/drop-files/DropFiles.vue
+++ b/src/components/ui/drop-files/DropFiles.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { defineProps, defineEmits, watch, onMounted } from 'vue';
+import { defineProps, defineEmits, watch } from 'vue';
 import { Button, Icon } from '#ds/index';
 import { useDropFiles } from './composables/useDropFiles';
 import type { DropFilesEmits, DropFilesProps } from './types';
@@ -50,7 +50,6 @@ const {
   startFile,
 } = useDropFiles(props, emit);
 
-onMounted(startFile);
 watch(() => props.file, startFile);
 
 defineOptions({

--- a/src/components/ui/drop-files/composables/useDropFiles.ts
+++ b/src/components/ui/drop-files/composables/useDropFiles.ts
@@ -185,7 +185,12 @@ export const useDropFiles = (props: DropFilesProps, emit: DropFilesEmits) => {
   };
 
   const startFile = () => {
-    if (props.file) validateAndProcessFile(props.file, false);
+    if (props.file) {
+      validateAndProcessFile(props.file, true);
+      return;
+    }
+
+    deleteFile(0);
   };
 
   const handleDragOver = () => {

--- a/src/components/ui/form-colorpicker/FormColorpicker.vue
+++ b/src/components/ui/form-colorpicker/FormColorpicker.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { getCurrentInstance, onMounted, ref, shallowRef, watchPostEffect } from 'vue';
+import { getCurrentInstance, onMounted, onUnmounted, ref, shallowRef, watchPostEffect } from 'vue';
 import Pickr from '@simonwep/pickr';
 import type PickerInterface from '@simonwep/pickr';
 import '@simonwep/pickr/dist/themes/monolith.min.css';
@@ -111,6 +111,12 @@ onMounted(() => {
       if (!focused.value) update(hexa);
     }
   });
+});
+
+onUnmounted(() => {
+  if (pickr.value) {
+    pickr.value.destroyAndRemove();
+  }
 });
 
 watchPostEffect(() => {


### PR DESCRIPTION
Foi identificado que os componentes **DropFiles** e **FormColorPicker** possuem problemas que afetam seu funcionamento correto. No DropFiles, o evento de atualização `update` não está enviando o arquivo atualizado corretamente e no **FormColorPicker**, as instâncias da biblioteca utilizada não estão sendo removidas ao desmontar o componente, causando a multiplicação desnecessária das mesmas.

### Changes:

- **ui/DropFiles:** corrigido o `update` para garantir o correto funcionamento da emissão de eventos, incluindo a exclusão de arquivos .
- **ui/FormColorPicker:** removidas instâncias da biblioteca ao desmontar o componente, evitando multiplicação indesejada.

### Evidências

![fix-dropfiles-colorpicker](https://github.com/user-attachments/assets/e77bf05f-1270-427a-b9fa-b391d951136a)

