### PR TITLE
[Fix] Ajuste no DropFiles para corrigir update ao montar e desmontar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tray-tecnologia/design-system",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tray-tecnologia/design-system",
-      "version": "4.2.2",
+      "version": "4.2.3",
       "dependencies": {
         "@codemirror/commands": "^6.6.2",
         "@codemirror/lang-css": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tray-tecnologia/design-system",
   "description": "Conjunto de diretrizes, componentes e padrões visuais e de código.",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "type": "module",
   "engines": {
     "node": ">=22.11.0"

--- a/src/components/ui/drop-files/DropFiles.stories.ts
+++ b/src/components/ui/drop-files/DropFiles.stories.ts
@@ -143,6 +143,33 @@ export const withFile: Story = {
   },
 };
 
+export const withFileUnmountedAndMounted: Story = {
+  render: (args: any) => ({
+    components: { DropFiles },
+    setup() {
+      const file = createMockFile({ name: 'example.txt', size: 1024, type: 'text/plain' });
+      args.file = file;
+
+      args.visible = true;
+
+      setTimeout(() => {
+        args.visible = false;
+      }, 500);
+
+      setTimeout(() => {
+        args.visible = true;
+      }, 800);
+
+      return { args };
+    },
+    template: `<div v-if="args.visible"> ${templateDropFiles}</div>`,
+  }),
+  args: {
+    ...configWithFile,
+    ...completeDropFilesActions,
+  },
+};
+
 export const withFileAndCustomClass: Story = {
   render: (args: any) => ({
     components: { DropFiles },

--- a/src/components/ui/drop-files/DropFiles.vue
+++ b/src/components/ui/drop-files/DropFiles.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { defineProps, defineEmits, watch } from 'vue';
+import { defineProps, defineEmits, watch, onMounted } from 'vue';
 import { Button, Icon } from '#ds/index';
 import { useDropFiles } from './composables/useDropFiles';
 import type { DropFilesEmits, DropFilesProps } from './types';
@@ -50,7 +50,16 @@ const {
   startFile,
 } = useDropFiles(props, emit);
 
-watch(() => props.file, startFile);
+onMounted(() => {
+  startFile(false);
+});
+
+watch(
+  () => props.file,
+  () => {
+    startFile();
+  }
+);
 
 defineOptions({
   inheritAttrs: false,

--- a/src/components/ui/drop-files/composables/useDropFiles.test.ts
+++ b/src/components/ui/drop-files/composables/useDropFiles.test.ts
@@ -62,7 +62,9 @@ const setup = (overrides: Partial<DropFilesProps> = {}, mockReturns: MockReturns
     vi.mocked(checkDimensionsError).mockReturnValue(mockReturns.checkDimensionsError);
   }
 
-  return { props, emit, ...useDropFiles(props, emit) };
+  const dropFiles = useDropFiles(props, emit);
+
+  return { props, emit, ...dropFiles };
 };
 
 const mockEvent = (file: File) => ({ target: { files: [file] } }) as unknown as Event;
@@ -366,6 +368,35 @@ describe('useDropFiles', () => {
 
       deleteFile(0);
 
+      expect(emit).toHaveBeenCalledWith('update', { fileName: null, file: null });
+    });
+  });
+
+  describe('startFile', () => {
+    test('Dado que não exista um arquivo nas props, Quando startFile for chamado sem parâmetro, Então deve chamar deleteFile', () => {
+      const { startFile, emit, fileList } = setup();
+
+      startFile();
+
+      expect(fileList.value).toHaveLength(0);
+      expect(emit).toHaveBeenCalledWith('update', { fileName: null, file: null });
+    });
+
+    test('Dado que não exista um arquivo nas props, Quando startFile for chamado com parâmetro false, Então não deve chamar deleteFile', () => {
+      const { startFile, emit, fileList } = setup();
+
+      startFile(false);
+
+      expect(fileList.value).toHaveLength(0);
+      expect(emit).not.toHaveBeenCalledWith('update', { fileName: null, file: null });
+    });
+
+    test('Dado que não exista um arquivo nas props, Quando startFile for chamado com parâmetro true, Então deve chamar deleteFile', () => {
+      const { startFile, emit, fileList } = setup();
+
+      startFile(true);
+
+      expect(fileList.value).toHaveLength(0);
       expect(emit).toHaveBeenCalledWith('update', { fileName: null, file: null });
     });
   });

--- a/src/components/ui/drop-files/composables/useDropFiles.ts
+++ b/src/components/ui/drop-files/composables/useDropFiles.ts
@@ -184,13 +184,13 @@ export const useDropFiles = (props: DropFilesProps, emit: DropFilesEmits) => {
     }
   };
 
-  const startFile = () => {
+  const startFile = (withUpdate: boolean = true) => {
     if (props.file) {
-      validateAndProcessFile(props.file, true);
+      validateAndProcessFile(props.file, withUpdate);
       return;
     }
 
-    deleteFile(0);
+    deleteFile(0, withUpdate);
   };
 
   const handleDragOver = () => {
@@ -201,14 +201,14 @@ export const useDropFiles = (props: DropFilesProps, emit: DropFilesEmits) => {
     if (!props.disabled) isDragging.value = false;
   };
 
-  const deleteFile = (index: number) => {
+  const deleteFile = (index: number, withUpdate: boolean = true) => {
     const fileName = fileList.value[index]?.file?.name ?? null;
 
     fileList.value.splice(index, 1);
 
     if (fileInput.value) fileInput.value.value = '';
 
-    emit('update', { fileName, file: null });
+    if (withUpdate) emit('update', { fileName, file: null });
   };
 
   return {


### PR DESCRIPTION
Pós a última alteração foi identificado que será necessário garantir que o componente **DropFiles** compile corretamente também no evento de montagem. Para isso, foi ajustado o código para compilar o arquivo sem disparar o evento de update, além de adicionar uma storie no Storybook que cobre o cenário de montagem e desmontagem, assegurando o comportamento esperado.

### Changes:

- **ui/DropFiles:** adicionada inicialização do arquivo na montagem do componente e adicionado cenário no Storybook para testar montagem e desmontagem.

### Evidências

![dropfiles-mounted-unmounted](https://github.com/user-attachments/assets/2ef37e97-d562-4241-9486-770862c6b57c)

