### PR TITLE
[Fix]  Correção do limite de resultados após a busca no FormAutoComplete

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tray-tecnologia/design-system",
   "description": "Conjunto de diretrizes, componentes e padrões visuais e de código.",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "type": "module",
   "engines": {
     "node": ">=22.11.0"

--- a/src/components/ui/form-autocomplete/FormAutocomplete.stories.ts
+++ b/src/components/ui/form-autocomplete/FormAutocomplete.stories.ts
@@ -22,3 +22,34 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+/** searchResultLimit parameter sets the maximum number of search results to display. In this example it is set to 2 */
+export const WithResultSearchLimit: Story = {
+  args: {
+    config: {
+      searchResultLimit: 2,
+    },
+    placeholder: 'Placeholder',
+    label: 'Label',
+    options: [
+      { value: 1, label: 'Hello' },
+      { value: 2, label: 'World' },
+      { value: 3, label: 'Foo' },
+      { value: 4, label: 'Foo' },
+      { value: 5, label: 'Foo' },
+      { value: 6, label: 'Foo' },
+      { value: 7, label: 'Foo' },
+      { value: 8, label: 'Foo' },
+      { value: 9, label: 'Foo' },
+      { value: 10, label: 'Foo' },
+      { value: 11, label: 'Foo' },
+      { value: 12, label: 'Foo' },
+      { value: 13, label: 'Foo' },
+      { value: 14, label: 'Foo' },
+      { value: 15, label: 'Foo' },
+      { value: 16, label: 'Bar' },
+      { value: 17, label: 'John' },
+      { value: 18, label: 'Doyle' },
+    ],
+  },
+};

--- a/src/components/ui/form-autocomplete/FormAutocomplete.vue
+++ b/src/components/ui/form-autocomplete/FormAutocomplete.vue
@@ -9,7 +9,9 @@ const emit = defineEmits(['update:modelValue', 'open', 'close', 'update']);
 const Plugin = Choices.default || Choices;
 const props = withDefaults(defineProps<FormAutocompleteProps>(), {
   placeholder: 'Selecione',
-  config: () => ({}),
+  config: () => ({
+    searchResultLimit: 20,
+  }),
   options: () => [],
   position: 'bottom',
   size: 'md',
@@ -41,7 +43,6 @@ const settings = computed(() => {
     items: [],
     choices: _choices,
     allowHTML: false,
-    searchResultLimit: 20,
     options: [],
     ...props.config,
   };


### PR DESCRIPTION
Tínhamos uma limitação fixa do resultado da busca no componente FormAutoComplete, com o ajuste estendemos a  possibilidade da configuração mas mantendo um padrão caso ela não seja configurada, no exemplo abaixo o limite foi configurado para 2 resultados.

### Changes:

- Adição da prop searchResult limit no componente FormAutoComplete

### Evidências:
![GravacaodeTela2025-03-03as17 36 46-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/734cd8e5-14ea-4df1-b81d-8e91920b40d1)

