### PR TITLE
Retorna a propriedade `state` removida anteriormente

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tray-tecnologia/design-system",
   "description": "Conjunto de diretrizes, componentes e padrões visuais e de código.",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "type": "module",
   "engines": {
     "node": ">=22.11.0"

--- a/src/components/ui/form-currency/FormCurrency.vue
+++ b/src/components/ui/form-currency/FormCurrency.vue
@@ -83,6 +83,7 @@ defineOptions({
     :disabled
     :label-info
     :float
+    :state
     :size
     :invalid-feedback>
     <input


### PR DESCRIPTION
### Descrição

Em outra atualização foi removido a propriedade `state` devido as modificações do contador de caracteres. Entretanto, remendo ela o `FormCurrency` parou de formatar corretamente o campo em estados válidos ou inválidos. Como o contador é um recurso que pode ser ativado, e visando não gerar impactos a  quem já usa, retornei a prop `state`, passando ela para o componente `FormWrapper`.