### PR TITLE
[Fix] Remover .replace fixo no FormTextfield

### DIFF
--- a/src/components/ui/form-textfield/FormTextfield.stories.ts
+++ b/src/components/ui/form-textfield/FormTextfield.stories.ts
@@ -27,6 +27,11 @@ const meta: Meta<typeof FormTextfield> = {
 		size: {
 			control: 'select',
 			options: ['sm', 'md', 'lg']
+		},
+		ignoreChars: {
+			control: 'text',
+			description:
+				'Characters to be ignored from the input value before comparing with `modelValue`. Useful for ignoring formatting symbols like `.` or `-`.'
 		}
 	}
 }

--- a/src/components/ui/form-textfield/FormTextfield.vue
+++ b/src/components/ui/form-textfield/FormTextfield.vue
@@ -43,6 +43,7 @@ const props = withDefaults(
 		max?: string | number
 		min?: string | number
 		dataMaskaTokens?: string
+		ignoreChars?: string
 	}>(),
 	{
 		state: undefined
@@ -78,7 +79,16 @@ const update = (evt: Event) => {
 
 const maskRawValue = (evt: Event) => {
 	const target = evt.target as HTMLInputElement
-	if (props.modelValue == target.value.replace(/\.|-/g, '')) return
+
+	let targetValue = target.value
+
+	if (props.ignoreChars) {
+		const regex = new RegExp(`[${props.ignoreChars.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')}]`, 'g')
+		targetValue = targetValue.replace(regex, '')
+	}
+
+	if (props.modelValue === targetValue) return
+
 	update(evt)
 	emit('updateRaw', target.dataset.maskRawValue)
 }


### PR DESCRIPTION
## [Fix] Remover .replace fixo no FormTextfield

[task link](https://github.com/uxshop/design-system/issues/435)

### Changes:

- Remove replace fixo do componente;
- Adiciona nova prop opcional `ignoreChars`, para realizar o replace com base em quem implementa o componente.

Exemplo de uso:

```vue 
<FormTextfield 
    v-model="reg.name" 
    label="Nome do produto" 
    placeholder="Ex: Camiseta Rosa Prime" 
    ignoreChars="-."
    required  
/>
```
