### PR TITLE
[Fix] Remover .replace fixo no FormTextfield

### DIFF
--- a/src/components/ui/form-textfield/FormTextfield.stories.ts
+++ b/src/components/ui/form-textfield/FormTextfield.stories.ts
@@ -42,6 +42,11 @@ const meta: Meta<typeof FormTextfield> = {
       control: 'select',
       options: ['sm', 'md', 'lg'],
     },
+    ignoreChars: {
+      control: 'text',
+      description:
+        'Caracteres a serem ignorados do valor de entrada antes de comparar com `modelValue`. Útil para desconsiderar símbolos de formatação como `.` ou `-`.',
+    },
   },
 };
 

--- a/src/components/ui/form-textfield/FormTextfield.test.ts
+++ b/src/components/ui/form-textfield/FormTextfield.test.ts
@@ -68,6 +68,14 @@ describe('FormTextfield', () => {
 
       expect(wrapper.vm.text).toBe('Novo valor');
     });
+
+    test('Dado um componente FormTextfield com ignoreChars, Quando o usuário digita caracteres ignorados, Então eles são desconsiderados na comparação, mas mantidos no modelValue', async () => {
+      const { wrapper, input } = createComponent({
+        ignoreChars: '.-',
+      });
+      await input().setValue('123.456-789');
+      expect(wrapper.props('modelValue')).toBe('123.456-789');
+    });
   });
 
   describe('Eventos', () => {

--- a/src/components/ui/form-textfield/FormTextfield.vue
+++ b/src/components/ui/form-textfield/FormTextfield.vue
@@ -38,7 +38,14 @@ const update = (evt: Event) => {
 
 const maskRawValue = (evt: Event) => {
   const target = evt.target as HTMLInputElement;
-  if (model.value === target.value.replace(/\.|-/g, '')) return;
+
+  let targetValue = target.value;
+  if (props.ignoreChars) {
+    const regex = new RegExp(`[${props.ignoreChars.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')}]`, 'g');
+    targetValue = targetValue.replace(regex, '');
+  }
+
+  if (model.value === targetValue) return;
 
   update(evt);
   emit('updateRaw', target.dataset.maskRawValue);

--- a/src/components/ui/form-textfield/types.ts
+++ b/src/components/ui/form-textfield/types.ts
@@ -32,4 +32,5 @@ export interface FormTextfieldProps extends FormWrapperProps {
   max?: string | number;
   min?: string | number;
   dataMaskaTokens?: string;
+  ignoreChars?: string;
 }


### PR DESCRIPTION
## [Fix] Remover .replace fixo no FormTextfield

[task link](https://github.com/uxshop/design-system/issues/435)

### Changes:

- Remove replace fixo do componente;
- Adiciona nova prop opcional `ignoreChars`, para realizar o replace com base em quem implementa o componente.

Exemplo de uso:

```vue 
<FormTextfield 
    v-model="reg.name" 
    label="Nome do produto" 
    placeholder="Ex: Camiseta Rosa Prime" 
    ignoreChars="-."
    required  
/>
```
