### PR TITLE
[Task] Ajustar comportamento de máscara em FormTextfield

### DIFF
--- a/src/components/ui/form-textfield/FormTextfield.vue
+++ b/src/components/ui/form-textfield/FormTextfield.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { vMaska } from 'maska';
-import { computed } from 'vue';
+import { computed, reactive } from 'vue';
 import Button from '../button/Button.vue';
 import FormWrapper from '../form-wrapper/FormWrapper.vue';
 import Icon from '../icon/Icon.vue';
@@ -18,6 +18,7 @@ const props = withDefaults(defineProps<FormTextfieldProps>(), {
 });
 const emit = defineEmits<FormTextfieldEmits>();
 
+const maskaObject = reactive<{ unmasked?: string }>({});
 const { currentMaxLength } = useMaxLength<FormTextfieldProps>(props);
 
 const classList = computed(() => [props.size ? `-${props.size}` : '']);
@@ -29,19 +30,10 @@ const maskOptions = computed<MaskOptions>(() => {
   };
 });
 
-const update = (evt: Event) => {
-  const target = evt.target as HTMLInputElement;
-  const val = target.value;
-
-  emit('update', val);
-};
-
 const maskRawValue = (evt: Event) => {
   const target = evt.target as HTMLInputElement;
-  if (model.value === target.value.replace(/\.|-/g, '')) return;
-
-  update(evt);
-  emit('updateRaw', target.dataset.maskRawValue);
+  emit('update', target.value);
+  emit('updateRaw', maskaObject.unmasked);
 };
 
 const onFocus = (event: Event) => {
@@ -104,10 +96,8 @@ const onInternalState = (state: boolean | undefined) => {
     <input
       :id
       v-model="model"
-      v-maska:[maskOptions]
+      v-maska:[maskOptions]="maskaObject"
       class="form-control"
-      :mask="mask"
-      :data-maska-tokens="dataMaskaTokens"
       :class="classList"
       :placeholder="!float ? placeholder : ''"
       :type

--- a/src/components/ui/form-textfield/types.ts
+++ b/src/components/ui/form-textfield/types.ts
@@ -31,5 +31,4 @@ export interface FormTextfieldProps extends FormWrapperProps {
   actions?: ActionButton[];
   max?: string | number;
   min?: string | number;
-  dataMaskaTokens?: string;
 }

--- a/src/components/ui/form-textfield/types.ts
+++ b/src/components/ui/form-textfield/types.ts
@@ -4,13 +4,13 @@ import type { FormWrapperProps } from '../form-wrapper';
 import type { FormWrapperEmits } from '../form-wrapper/types';
 
 export interface FormTextfieldEmits extends FormWrapperEmits {
-  (event: 'update', value: any): void;
+  (event: 'update', value: string | null): void;
   (e: 'focus', event: Event): void;
   (e: 'blur', event: Event): void;
   (e: 'keydown', event: Event): void;
   (e: 'keydownEnter', event: Event): void;
   (e: 'clear'): void;
-  (e: 'updateRaw', val: any): void;
+  (e: 'updateRaw', val: string | undefined): void;
 }
 
 export interface FormTextfieldProps extends FormWrapperProps {

--- a/src/components/ui/form-textfield/types.ts
+++ b/src/components/ui/form-textfield/types.ts
@@ -10,6 +10,7 @@ export interface FormTextfieldEmits extends FormWrapperEmits {
   (e: 'keydown', event: Event): void;
   (e: 'keydownEnter', event: Event): void;
   (e: 'clear'): void;
+  /** Emite o valor inserido no FormTextfield sem máscaras */
   (e: 'updateRaw', val: string | undefined): void;
 }
 


### PR DESCRIPTION
## [Task] Ajustar comportamento de máscara em FormTextfield

### Changes:
- Substituição do controle manual de máscara `(maskRawValue)` para integração direta com o `maskaObject`.
- Atualização do `<input>` para usar `v-maska:[maskOptions]="maskaObject"`.
- Emissão do evento `updateRaw` com valor sem máscara `(maskaObject.unmasked)`.
- Atualização da tipagem `FormTextfieldEmits`, garantindo `update` e `updateRaw` com tipo string.