### PR TITLE
[Hotfix] corrige valor de tag de filtragem por updated_at na TableListTags

### DIFF
--- a/src/components/admin/table-list/table-list-tags/TableListTags.vue
+++ b/src/components/admin/table-list/table-list-tags/TableListTags.vue
@@ -45,7 +45,7 @@ const translateValue = (item: any, key: string) => {
 		return item
 	}
 
-	if (key == 'created_at') {
+	if (key == 'updated_at' || key == 'created_at') {
 		return dateFormat(item)
 	}
 


### PR DESCRIPTION


## [Hotfix] corrige valor de tag de filtragem por updated_at na TableListTags

[Bug 24949](https://dev.azure.com/doocacom/Platform/_workitems/edit/24949): Erro visual ao exibir filtro updated_at

### Changes:

- corrige formatacao de valor de tag de filtro para quando o campo de filtragem for updated_at
