### PR TITLE
[Hotfix] corrige translate de valor de filtro quando for category_id

### DIFF
--- a/src/components/admin/table-list/table-list-tags/TableListTags.vue
+++ b/src/components/admin/table-list/table-list-tags/TableListTags.vue
@@ -45,7 +45,7 @@ const translateValue = (item: any, key: string) => {
     return dateFormat(item);
   }
 
-  if (key === 'q' || key === 'category_ids') {
+  if (key === 'q') {
     return item;
   }
 


### PR DESCRIPTION
## [Task] Task title board

[task link](https://dev.azure.com/doocacom/Platform/_sprints/taskboard/squad-checkout/Platform/checkout/2025/sprint%2020?workitem=26321)
<img width="737" height="585" alt="image" src="https://github.com/user-attachments/assets/e83d6da3-cc32-478f-be3d-a27f044e012d" />


### Changes:

- resgata nome da categoria escolhida buscado nome que corresponde com id selecionado nos filters
