### PR TITLE
[Hotfix] corrige translate de valor de filtro nas tags para filtro de categoria

### DIFF
--- a/src/components/admin/table-list/table-list-tags/TableListTags.vue
+++ b/src/components/admin/table-list/table-list-tags/TableListTags.vue
@@ -49,7 +49,7 @@ const translateValue = (item: any, key: string) => {
 		return dateFormat(item)
 	}
 
-	if (key == 'q' || key == 'category_ids') {
+	if (key == 'q') {
 		return item
 	}
 


### PR DESCRIPTION
## [Hotfix] corrige translate de valor de filtro nas tags para filtro de categoria

[task link](https://dev.azure.com/doocacom/Platform/_sprints/taskboard/squad-checkout/Platform/checkout/2025/sprint%2020?workitem=26321)

<img width="737" height="585" alt="image" src="https://github.com/user-attachments/assets/9faf284e-3a6b-4523-a4f4-71eebcb93f07" />


### Changes:

- corrige translate para buscar nome de categoria com base no id nos filtros
