### PR TITLE
[Task] remove filtro quando seu valor nao existe

### DIFF
--- a/src/components/admin/table-list/table-list-tags/TableListTags.vue
+++ b/src/components/admin/table-list/table-list-tags/TableListTags.vue
@@ -79,6 +79,8 @@ const translateValue = async (item: any, key: string) => {
 				const obj = find(props.state.config.filters[k]?.filters, { value: v })
 				if (obj) {
 					val.push(obj.name)
+				} else {
+					props.state.removeFilter(k)
 				}
 			})
 		}


### PR DESCRIPTION
## [Task] remove filtro quando seu valor nao existe

[Bug 27193](https://dev.azure.com/doocacom/Platform/_workitems/edit/27193): Erro ao filtrar pedidos com um gateway re-instalado

### Changes:

- caso seja passado um filtro que não tem valor de referência, o filtro é removido
