### PR TITLE
[Task] corrige limpesa de filtro de data

### DIFF
--- a/src/components/admin/table-list/table-list-nav-filter/TableListNavFilterSidebar.vue
+++ b/src/components/admin/table-list/table-list-nav-filter/TableListNavFilterSidebar.vue
@@ -63,6 +63,7 @@ const onClearFilter = (filter: { type: string }, key: string | number) => {
 
 		case 'date_range':
 			clearPickerDate(key as string)
+			selected.value[key] = null
 			break
 
 		default:


### PR DESCRIPTION
## [Task] corrige limpesa de filtro de data

[task link](https://dev.azure.com/doocacom/Platform/_sprints/taskboard/squad-checkout/Platform/checkout/2025/sprint%2023?workitem=27184)

<img width="921" height="179" alt="imagem" src="https://github.com/user-attachments/assets/4ed09608-0b26-4b77-835b-3dc4562fba78" />


### Changes:

- após a compilação do TS o compoenente datepicker perde a responsividade, para isso foi feita uma correção para que a limpesa do filtro datepicker reflita no componente
