### PR TITLE
[Fix] corrige limpeza de filtros do TableListNavFilterSideBar quando o filtro é BrowserSelect

### DIFF
--- a/src/components/admin/browser-select/BrowserSelect.vue
+++ b/src/components/admin/browser-select/BrowserSelect.vue
@@ -6,6 +6,7 @@ import Button from '../../ui/button/Button.vue'
 import IconButton from '../../ui/icon-button/IconButton.vue'
 import Link from '../../ui/link/Link.vue'
 import BrowserSelectModal from './BrowserSelectModal.vue'
+import SkeletonList from '../../ui/skeleton-list/SkeletonList.vue'
 
 export interface Props {
 	modelValue: any
@@ -50,6 +51,7 @@ const memoryList = ref([])
 const paginateStart = ref(0)
 const paginateLimit = ref(props.paginateListLimit)
 const browserSelectModalRef = ref()
+const loading = ref(false)
 
 const onClickSearch = () => {
 	browserSelectModalRef.value.open({
@@ -71,8 +73,6 @@ const nextPage = async () => {
 }
 
 const onRemoveItem = (item: any) => {
-	emit('remove', item)
-
 	if (find(rows.value, { [props.identifier]: item[props.identifier] })) {
 		rows.value = rows.value.filter((obj) => {
 			return obj[props.identifier] != item[props.identifier]
@@ -86,6 +86,7 @@ const onRemoveItem = (item: any) => {
 	})
 
 	updateInput(selectedIds.value)
+	emit('remove', item)
 }
 
 const updateInput = (ids: number[]) => {
@@ -125,6 +126,7 @@ const getItemsList = async () => {
 }
 
 const fetch = async () => {
+	loading.value = true
 	let newRows: unknown[] = []
 
 	if (selectedIds.value.length) {
@@ -142,6 +144,7 @@ const fetch = async () => {
 	}
 
 	rows.value = newRows
+	loading.value = false
 }
 
 const populateList = (newVal: any) => {
@@ -245,6 +248,7 @@ defineExpose({ onClickSearch })
 
 			<div class="ui-browser-list" v-if="!hideList && rows.length">
 				<div
+					v-if="!loading"
 					v-for="item in rows.slice(0, paginateLimit)"
 					class="ui-browser-list-row"
 					:class="{ '-no-button': hideExcludeButton }"
@@ -256,6 +260,9 @@ defineExpose({ onClickSearch })
 					<div v-if="!hideExcludeButton" class="ui-browser-list-cell -auto">
 						<IconButton variant="plain" size="sm" icon="close" @click="onRemoveItem(item)" />
 					</div>
+				</div>
+				<div v-if="loading">
+					<SkeletonList :rows="3" />
 				</div>
 				<div v-if="rows.length > paginateLimit" class="ui-browser-list-more">
 					<Link @click="nextPage" label="Exibir mais" />

--- a/src/components/admin/browser-select/BrowserSelect.vue
+++ b/src/components/admin/browser-select/BrowserSelect.vue
@@ -126,25 +126,30 @@ const getItemsList = async () => {
 }
 
 const fetch = async () => {
-	loading.value = true
-	let newRows: unknown[] = []
+	try {
+		loading.value = true
+		let newRows: unknown[] = []
 
-	if (selectedIds.value.length) {
-		getFromMemoryList(newRows)
+		if (selectedIds.value.length) {
+			getFromMemoryList(newRows)
 
-		if (newRows.length != selectedIds.value.length) {
-			if (props.selectOne) {
-				const id = selectedIds.value[0]
-				newRows = await props.service.first(id)
-				newRows = [newRows]
-			} else {
-				newRows = await getItemsList()
+			if (newRows.length != selectedIds.value.length) {
+				if (props.selectOne) {
+					const id = selectedIds.value[0]
+					newRows = await props.service.first(id)
+					newRows = [newRows]
+				} else {
+					newRows = await getItemsList()
+				}
 			}
 		}
-	}
 
-	rows.value = newRows
-	loading.value = false
+		rows.value = newRows
+	} catch (error) {
+		console.error(error)
+	} finally {
+		loading.value = false
+	}
 }
 
 const populateList = (newVal: any) => {

--- a/src/components/admin/table-list/table-list-nav-filter/TableListNavFilterSidebar.vue
+++ b/src/components/admin/table-list/table-list-nav-filter/TableListNavFilterSidebar.vue
@@ -104,6 +104,10 @@ const setCurrentFilters = async () => {
 	}
 }
 
+const onBrowserSelectRemoveItem = (item: any, key: string) => {
+	selected.value[key] = selected.value[key].filter((id: number) => id !== item.id)
+}
+
 const open = async () => {
 	reset()
 	await setCurrentFilters()
@@ -132,6 +136,8 @@ defineExpose({
 						<div v-if="filter.type == 'browser'">
 							<BrowserSelect
 								v-model="selected[key]"
+								:list="selected[key]"
+								@remove="(item) => onBrowserSelectRemoveItem(item, key)"
 								:name="`check_${key}`"
 								:type="filter.model"
 								:service="filter.service"


### PR DESCRIPTION
## [Fix] corrige limpeza de filtros do TableListNavFilterSideBar quando o filtro é BrowserSelect


[Bug 27664](https://dev.azure.com/doocacom/Platform/_workitems/edit/27664): Erro ao tentar limpar o filtro de gateways de pagamento

### Changes:

- no BrowserSelect emite evento de remove item ao final ca callback de remoção de item pela lista para que toda lógica seja executada antes da emissão do evento.
- TableListNavFilterSideBar passa a lista para o browserSelect de acordo com os items selecionados para que a listagem do browser select seja atualizada caso houver mudança nos filtros selecionados.
